### PR TITLE
Add a tunnel option for JNLP connection from agent to master

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
@@ -40,15 +40,23 @@ public class DockerSwarmCloud extends Cloud {
     private String jenkinsUrl;
     private String swarmNetwork;
     private String cacheDriverName;
+    private String tunnel;
     private List<DockerSwarmAgentTemplate> agentTemplates = new ArrayList<>();
 
     @DataBoundConstructor
-    public DockerSwarmCloud(String dockerSwarmApiUrl, String jenkinsUrl, String swarmNetwork, String cacheDriverName, List<DockerSwarmAgentTemplate> agentTemplates) {
+    public DockerSwarmCloud(
+            String dockerSwarmApiUrl,
+            String jenkinsUrl,
+            String swarmNetwork,
+            String cacheDriverName,
+            String tunnel,
+            List<DockerSwarmAgentTemplate> agentTemplates) {
         super(DOCKER_SWARM_CLOUD_NAME);
         this.dockerSwarmApiUrl = dockerSwarmApiUrl;
         this.jenkinsUrl = jenkinsUrl;
         this.swarmNetwork = swarmNetwork;
         this.cacheDriverName = cacheDriverName;
+        this.tunnel = tunnel;
         this.agentTemplates = agentTemplates;
     }
 
@@ -117,6 +125,10 @@ public class DockerSwarmCloud extends Cloud {
 
     public String getCacheDriverName() {
         return cacheDriverName;
+    }
+    
+    public String getTunnel() {
+        return tunnel;
     }
 
     public List<DockerSwarmAgentTemplate> getAgentTemplates() {

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
@@ -9,6 +9,7 @@ import hudson.model.TaskListener;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.SlaveComputer;
 import jenkins.model.Jenkins;
+import jenkins.slaves.RemotingWorkDirSettings;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.docker.swarm.docker.api.service.ServiceSpec;
 
@@ -22,6 +23,16 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
 
 
     public DockerSwarmComputerLauncher(final Queue.BuildableItem bi) {
+        super(
+                DockerSwarmCloud.get().getTunnel(),
+                null,
+                new RemotingWorkDirSettings(
+                        false,
+                        "/tmp",
+                        null,
+                        false
+                )
+        );
         this.bi = bi;
         this.label = bi.task.getAssignedLabel().getName();
         this.jobName = bi.task instanceof AbstractProject ? ((AbstractProject) bi.task).getFullName() : bi.task.getName();
@@ -47,7 +58,7 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
         if (envVarOptions.length != 0) {
             System.arraycopy(envVarOptions, 0, envVars, 0, envVarOptions.length);
         }
-        final String agentOptions = String.join(" ", "-jnlpUrl", getAgentJnlpUrl(computer, configuration), "-secret", getAgentSecret(computer), "-noReconnect -workDir /tmp");
+        final String agentOptions = String.join(" ", "-jnlpUrl", getAgentJnlpUrl(computer, configuration), "-secret", getAgentSecret(computer), "-noReconnect");
         String interpreter;
         String interpreterOptions;
         String fetchAndLaunchCommand;

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud/config.jelly
@@ -15,6 +15,9 @@
         <f:entry title="Cache driver name" field="cacheDriverName">
             <f:textbox/>
         </f:entry>
+        <f:entry title="Tunnel" field="tunnel">
+            <f:textbox/>
+        </f:entry>
 
     </f:section>
     <f:advanced title="${%Docker Agent templates}" align="left">


### PR DESCRIPTION
I need a tunnel to access master's JNLP port, as it is behind a proxy (see #20).
This PR allows it