### PR TITLE
Add working dir option for pipeline execution

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
@@ -29,7 +29,7 @@ public class DockerSwarmAgent extends AbstractCloudSlave implements EphemeralNod
                 labelString,
                 "Docker swarm agent for building " + bi.task.getFullDisplayName(),
                 DockerSwarmCloud.get()
-                                .getLabelConfiguration(labelString)
+                                .getLabelConfiguration(bi.task.getAssignedLabel().getName())
                                 .getWorkingDir(),
                 1,
                 Mode.EXCLUSIVE,

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
@@ -25,11 +25,19 @@ public class DockerSwarmAgent extends AbstractCloudSlave implements EphemeralNod
     private static final Logger LOGGER = Logger.getLogger(DockerSwarmAgent.class.getName());
 
     public DockerSwarmAgent(final Queue.BuildableItem bi, final String labelString) throws Descriptor.FormException, IOException {
-        super(labelString, "Docker swarm agent for building " + bi.task.getFullDisplayName(),
-                "/home/jenkins", 1, Mode.EXCLUSIVE, labelString,
+        super(
+                labelString,
+                "Docker swarm agent for building " + bi.task.getFullDisplayName(),
+                DockerSwarmCloud.get()
+                                .getLabelConfiguration(labelString)
+                                .getWorkingDir(),
+                1,
+                Mode.EXCLUSIVE,
+                labelString,
                 new DockerSwarmComputerLauncher(bi),
                 new DockerSwarmAgentRetentionStrategy(1),
-                Collections.emptyList());
+                Collections.emptyList()
+        );
     }
 
     public DockerSwarmComputer createComputer() {

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
@@ -19,7 +19,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
     private String hostBinds;
     private String label;
     private boolean osWindows;
-
+    private String workingDir;
 
     private String cacheDir;
     private String envVars;
@@ -35,8 +35,14 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
                                     final String label,
                                     final String cacheDir, final String tmpfsDir,
                                     final String envVars,
-                                    final long limitsNanoCPUs, final long limitsMemoryBytes,
-                                    final long reservationsNanoCPUs, final long reservationsMemoryBytes, final boolean osWindows, final String baseWorkspaceLocation, final String placementConstraints) {
+                                    final long limitsNanoCPUs,
+                                    final long limitsMemoryBytes,
+                                    final long reservationsNanoCPUs,
+                                    final long reservationsMemoryBytes,
+                                    final boolean osWindows,
+                                    String workingDir,
+                                    final String baseWorkspaceLocation,
+                                    final String placementConstraints) {
         this.image = image;
         this.hostBinds = hostBinds;
         this.label = label;
@@ -48,6 +54,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
         this.reservationsMemoryBytes = reservationsMemoryBytes;
         this.envVars = envVars;
         this.osWindows = osWindows;
+        this.workingDir = workingDir;
         this.baseWorkspaceLocation = baseWorkspaceLocation;
         this.placementConstraints = placementConstraints;
     }
@@ -113,6 +120,10 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
 
     public boolean isOsWindows() {
         return osWindows;
+    }
+    
+    public String getWorkingDir() {
+        return workingDir == null ? "/home/jenkins" : workingDir;
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
@@ -40,15 +40,23 @@ public class DockerSwarmCloud extends Cloud {
     private String jenkinsUrl;
     private String swarmNetwork;
     private String cacheDriverName;
+    private String tunnel;
     private List<DockerSwarmAgentTemplate> agentTemplates = new ArrayList<>();
 
     @DataBoundConstructor
-    public DockerSwarmCloud(String dockerSwarmApiUrl, String jenkinsUrl, String swarmNetwork, String cacheDriverName, List<DockerSwarmAgentTemplate> agentTemplates) {
+    public DockerSwarmCloud(
+            String dockerSwarmApiUrl,
+            String jenkinsUrl,
+            String swarmNetwork,
+            String cacheDriverName,
+            String tunnel,
+            List<DockerSwarmAgentTemplate> agentTemplates) {
         super(DOCKER_SWARM_CLOUD_NAME);
         this.dockerSwarmApiUrl = dockerSwarmApiUrl;
         this.jenkinsUrl = jenkinsUrl;
         this.swarmNetwork = swarmNetwork;
         this.cacheDriverName = cacheDriverName;
+        this.tunnel = tunnel;
         this.agentTemplates = agentTemplates;
     }
 
@@ -117,6 +125,10 @@ public class DockerSwarmCloud extends Cloud {
 
     public String getCacheDriverName() {
         return cacheDriverName;
+    }
+    
+    public String getTunnel() {
+        return tunnel;
     }
 
     public List<DockerSwarmAgentTemplate> getAgentTemplates() {

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
@@ -9,6 +9,7 @@ import hudson.model.TaskListener;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.SlaveComputer;
 import jenkins.model.Jenkins;
+import jenkins.slaves.RemotingWorkDirSettings;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.docker.swarm.docker.api.service.ServiceSpec;
 
@@ -22,6 +23,16 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
 
 
     public DockerSwarmComputerLauncher(final Queue.BuildableItem bi) {
+        super(
+                DockerSwarmCloud.get().getTunnel(),
+                null,
+                new RemotingWorkDirSettings(
+                        false,
+                        "/tmp",
+                        null,
+                        false
+                )
+        );
         this.bi = bi;
         this.label = bi.task.getAssignedLabel().getName();
         this.jobName = bi.task instanceof AbstractProject ? ((AbstractProject) bi.task).getFullName() : bi.task.getName();
@@ -47,7 +58,7 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
         if (envVarOptions.length != 0) {
             System.arraycopy(envVarOptions, 0, envVars, 0, envVarOptions.length);
         }
-        final String agentOptions = String.join(" ", "-jnlpUrl", getAgentJnlpUrl(computer, configuration), "-secret", getAgentSecret(computer), "-noReconnect -workDir /tmp");
+        final String agentOptions = String.join(" ", "-jnlpUrl", getAgentJnlpUrl(computer, configuration), "-secret", getAgentSecret(computer), "-noReconnect");
         String interpreter;
         String interpreterOptions;
         String fetchAndLaunchCommand;

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
@@ -26,6 +26,9 @@
     <f:entry title="Workspace Location" field="baseWorkspaceLocation">
         <f:textbox value="${dockerSwarmAgentTemplate.baseWorkspaceLocation}"/>
     </f:entry>
+    <f:entry title="Working directory" field="workingDir">
+        <f:textbox value="${dockerSwarmAgentTemplate.workingDir}"/>
+    </f:entry>
     <f:advanced title="${%Placement}" align="left">
         <f:section title="Placement">
             <f:entry title="Constraints" field="placementConstraints">

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud/config.jelly
@@ -15,6 +15,9 @@
         <f:entry title="Cache driver name" field="cacheDriverName">
             <f:textbox/>
         </f:entry>
+        <f:entry title="Tunnel" field="tunnel">
+            <f:textbox/>
+        </f:entry>
 
     </f:section>
     <f:advanced title="${%Docker Agent templates}" align="left">


### PR DESCRIPTION
I need a custom working dir to execute my pipeline into, as my docker image is not run as root and I have a special folder which belongs to my user (see #22)
This PR allows it.

There are 2 commits in this branch, of which the first is the same as #23.

This option is already covered by #1, so if this PR is merged the current one won't have a reason to exist anymore.