### PR TITLE
Add option to add supplemental hosts in container's /etc/hosts

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
@@ -24,6 +24,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
     private String command;
     private String user;
     private String workingDir;
+    private String hosts;
 
     private String cacheDir;
     private String envVars;
@@ -39,6 +40,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
                                     final String command,
                                     final String user,
                                     final String workingDir,
+                                    final String hosts,
                                     final String secrets,
                                     final String configs,
                                     final String label,
@@ -56,6 +58,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
         this.command = command;
         this.user = user;
         this.workingDir = workingDir;
+        this.hosts = hosts;
         this.secrets = secrets;
         this.configs = configs;
         this.label = label;
@@ -101,6 +104,10 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
 
     public String[] getCommandConfig() {
         return StringUtils.isEmpty(this.command) ? new String[]{} : this.command.split("[\\r\\n]+");
+    }
+
+    public String[] getHostsConfig() {
+        return StringUtils.isEmpty(this.hosts) ? new String[]{} : this.hosts.split("[\\r\\n]+");
     }
 
     public long getLimitsNanoCPUs() {
@@ -163,6 +170,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
     public String getSecrets() { return secrets; }
     public String getConfigs() { return configs; }
     public String getCommand() { return command; }
+    public String getHosts() { return hosts; }
     public String getCacheDir() { return cacheDir;  }
     public String getUser() { return user; }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/containers/ContainerSpec.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/containers/ContainerSpec.java
@@ -11,19 +11,21 @@ public class ContainerSpec {
     public final String Dir;
     public final String User;
     public List<Mount> Mounts = new ArrayList<>();
+    public final String[] Hosts;
     public List<Secret> Secrets = new ArrayList<>();
     public List<Config> Configs = new ArrayList<>();
 
     public ContainerSpec() {
-        this(null, null, null, null, null);
+        this(null, null, null, null, null, null);
     }
 
-    public ContainerSpec(String image, String[] cmd, String[] env, String dir, String user) {
+    public ContainerSpec(String image, String[] cmd, String[] env, String dir, String user, String[] hosts) {
         this.Image = image;
         this.Command = cmd;
         this.Env = env;
         this.Dir = dir;
         this.User = user;
+        this.Hosts = hosts;
     }
 
     public static class Secret {

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/service/ServiceSpec.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/service/ServiceSpec.java
@@ -21,10 +21,10 @@ public class ServiceSpec extends ApiRequest {
     public Map<String,String> Labels = new HashMap<>();
 
     public List<Network> Networks = new ArrayList<>();
-    public ServiceSpec(String name, String Image, String[] Cmd, String[] Env, String Dir, String User) throws IOException {
+    public ServiceSpec(String name, String Image, String[] Cmd, String[] Env, String Dir, String User, String[] Hosts) throws IOException {
         super(HttpMethod.POST, "/services/create",CreateServiceResponse.class, ResponseType.CLASS);
         this.Name = name;
-        this.TaskTemplate = new TaskTemplate(Image,Cmd,Env,Dir,User);
+        this.TaskTemplate = new TaskTemplate(Image, Cmd, Env, Dir, User, Hosts);
     }
 
     public ServiceSpec() throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/task/TaskTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/task/TaskTemplate.java
@@ -15,9 +15,8 @@ public class TaskTemplate {
        //for reading from api
     }
 
-    public TaskTemplate(String image, String[] cmd, String[] env, String dir, String user) {
-        this.ContainerSpec = new ContainerSpec(image,cmd,env,dir,user);
-
+    public TaskTemplate(String image, String[] cmd, String[] env, String dir, String user, String[] hosts) {
+        this.ContainerSpec = new ContainerSpec(image, cmd, env, dir, user, hosts);
     }
 
     public void setPlacementConstraints(String[] placementConstraints) {

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
@@ -20,6 +20,9 @@
     <f:entry title="Env (newline-separated)" field="envVars">
         <f:expandableTextbox value="${dockerSwarmAgentTemplate.envVars}"/>
     </f:entry>
+    <f:entry title="Additional hosts (newline-separated)" field="hosts">
+        <f:expandableTextbox value="${dockerSwarmAgentTemplate.hosts}"/>
+    </f:entry>
     <f:entry title="Host Binds (newline-separated)"
              field="hostBinds">
         <f:expandableTextbox value="${dockerSwarmAgentTemplate.hostBinds}"/>

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/help-hosts.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/help-hosts.html
@@ -1,0 +1,7 @@
+<div>
+    <p>Additional hosts to add to container's /etc/hosts file</p>
+    <p>Each entry must be in the form &lt;IP_address canonical_hostname [aliases...]&gt; e.g :</p>
+    <code>
+127.0.0.1 example.com example
+    </code>
+</div>


### PR DESCRIPTION
Adds the functionnality of adding supplemental hosts in the container's /etc/hosts file.
This is not possible during image creation, and if your container doesn't run as root, you can't do it at runtime.