### PR TITLE
Support swarm agent provisioning when label is assigned dynamically

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
@@ -28,8 +28,8 @@ public class DockerSwarmAgent extends AbstractCloudSlave implements EphemeralNod
     public DockerSwarmAgent(final Queue.BuildableItem bi, final String labelString)
             throws Descriptor.FormException, IOException {
         super(labelString, "Docker swarm agent for building " + bi.task.getFullDisplayName(),
-                DockerSwarmCloud.get().getLabelConfiguration(bi.task.getAssignedLabel().getName()).getWorkingDir(), 1,
-                Mode.EXCLUSIVE, labelString, new DockerSwarmComputerLauncher(bi),
+                DockerSwarmCloud.get().getLabelConfiguration(bi.getAssignedLabel().getName()).getWorkingDir(), 1,
+                Mode.EXCLUSIVE, bi.getAssignedLabel().getName(), new DockerSwarmComputerLauncher(bi),
                 new DockerSwarmAgentRetentionStrategy(1), Collections.emptyList());
         LOGGER.log(Level.FINE, "Created docker swarm agent: {0}", labelString);
     }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
@@ -47,7 +47,7 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
     public DockerSwarmComputerLauncher(final Queue.BuildableItem bi) {
         super(DockerSwarmCloud.get().getTunnel(), null, new RemotingWorkDirSettings(false, "/tmp", null, false));
         this.bi = bi;
-        this.label = bi.task.getAssignedLabel().getName();
+        this.label = bi.getAssignedLabel().getName();
         this.jobName = bi.task instanceof AbstractProject ? ((AbstractProject) bi.task).getFullName()
                 : bi.task.getName();
     }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/OneShotProvisionQueueListener.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/OneShotProvisionQueueListener.java
@@ -19,10 +19,9 @@ public class OneShotProvisionQueueListener extends QueueListener {
 
     @Override
     public void onEnterBuildable(final Queue.BuildableItem bi) {
-        final Queue.Task job = bi.task;
         if (DockerSwarmCloud.get() != null) {
             final List<String> labels = DockerSwarmCloud.get().getLabels();
-            if (job.getAssignedLabel() != null && labels.contains(job.getAssignedLabel().getName())) {
+            if (bi.getAssignedLabel() != null && labels.contains(bi.getAssignedLabel().getName())) {
                 BuildScheduler.scheduleBuild(bi);
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/dashboard/SwarmQueueItem.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/dashboard/SwarmQueueItem.java
@@ -20,7 +20,7 @@ public class SwarmQueueItem {
 
     public SwarmQueueItem(final Queue.BuildableItem item) {
         this.name = item.task.getFullDisplayName();
-        this.label = item.task.getAssignedLabel().getName();
+        this.label = item.getAssignedLabel().getName();
         this.labelConfig = DockerSwarmCloud.get().getLabelConfiguration(this.label);
         this.inQueueSince = item.getInQueueForString();
         this.agentInfo = item.getAction(DockerSwarmAgentInfo.class); // this should never be null


### PR DESCRIPTION
Hi, 
In a multi-configuration project, the groovy-label-assignment plugin is used to assign labels dynamically to various job configurations (variants). It allows to provision a different docker agent depending of the variant to build within a same project (docker image is different depending of the variant).

Here are the small changes required to trigger and provision the docker-swarm agent using Docker Swarm Plugin with Groovy Label Assignment.