### PR TITLE
Add npipe option to build docker containers from a swarm Windows service

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
@@ -25,6 +25,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
     private long reservationsMemoryBytes;
     private String image;
     private String hostBinds;
+    private String hostNamedPipes;
     private String secrets;
     private String configs;
     private String dnsIps;
@@ -49,7 +50,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
     }
 
     @DataBoundConstructor
-    public DockerSwarmAgentTemplate(final String image, final String hostBinds, final String dnsIps,
+    public DockerSwarmAgentTemplate(final String image, final String hostBinds, final String hostNamedPipes, final String dnsIps,
             final String dnsSearchDomains, final String command, final String user, final String workingDir,
             final String hosts, final String secrets, final String configs, final String label, final String cacheDir,
             final String tmpfsDir, final String envVars, final long limitsNanoCPUs, final long limitsMemoryBytes,
@@ -58,6 +59,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
             final String serverAddress, final String pullCredentialsId) {
         this.image = image;
         this.hostBinds = hostBinds;
+        this.hostNamedPipes = hostNamedPipes;
         this.dnsIps = dnsIps;
         this.dnsSearchDomains = dnsSearchDomains;
         this.command = command;
@@ -96,6 +98,10 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
 
     public String[] getHostBindsConfig() {
         return StringUtils.isEmpty(this.hostBinds) ? new String[] {} : this.hostBinds.split("[\\r\\n ]+");
+    }
+
+    public String[] getHostNamedPipesConfig() {
+        return StringUtils.isEmpty(this.hostNamedPipes) ? new String[] {} : this.hostNamedPipes.split("[\\r\\n ]+");
     }
 
     public String[] getSecretsConfig() {
@@ -197,6 +203,10 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
 
     public String getHostBinds() {
         return hostBinds;
+    }
+
+    public String getHostNamedPipes() {
+        return hostNamedPipes;
     }
 
     public String getSecrets() {

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
@@ -129,6 +129,7 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
 
         setLimitsAndReservations(dockerSwarmAgentTemplate, crReq);
         setHostBinds(dockerSwarmAgentTemplate, crReq);
+        setHostNamedPipes(dockerSwarmAgentTemplate, crReq);
         setSecrets(dockerSwarmAgentTemplate, crReq);
         setConfigs(dockerSwarmAgentTemplate, crReq);
         setNetwork(configuration, crReq);
@@ -208,6 +209,15 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
             String hostBind = hostBinds[i];
             String[] srcDest = hostBind.split(":");
             crReq.addBindVolume(srcDest[0], srcDest[1]);
+        }
+    }
+
+    private void setHostNamedPipes(DockerSwarmAgentTemplate dockerSwarmAgentTemplate, ServiceSpec crReq) {
+        String[] hostNamedPipes = dockerSwarmAgentTemplate.getHostNamedPipesConfig();
+        for (int i = 0; i < hostNamedPipes.length; i++) {
+            String hostNamedPipe = hostNamedPipes[i];
+            String[] srcDest = hostNamedPipe.split(":");
+            crReq.addNamedPipeVolume(srcDest[0], srcDest[1]);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/containers/ContainerSpec.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/containers/ContainerSpec.java
@@ -157,6 +157,12 @@ public class ContainerSpec {
             return mount;
         }
 
+        public static Mount namedPipeMount(String Source, String Target) {
+            Mount mount = new Mount(Source, Target);
+            mount.Type = "npipe";
+            return mount;
+        }
+
         public static class VolumeOptions {
             public Mount.VolumeOptions.DriverConfig DriverConfig;
 

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/service/ServiceSpec.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/service/ServiceSpec.java
@@ -41,6 +41,11 @@ public class ServiceSpec extends ApiRequest {
         ContainerSpec.Mount mount = ContainerSpec.Mount.bindMount(source, target);
         this.TaskTemplate.ContainerSpec.Mounts.add(mount);
     }
+    
+    public void addNamedPipeVolume(String source, String target) {
+        ContainerSpec.Mount mount = ContainerSpec.Mount.namedPipeMount(source, target);
+        this.TaskTemplate.ContainerSpec.Mounts.add(mount);
+    }
 
     public void addSecret(String secretId, String secretName, String fileName) {
         ContainerSpec.Secret secret = ContainerSpec.Secret.createSecret(secretId, secretName, fileName);

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
@@ -27,6 +27,9 @@
     <f:entry title="Host Binds (newline-separated)" field="hostBinds">
         <f:expandableTextbox value="${dockerSwarmAgentTemplate.hostBinds}"/>
     </f:entry>
+    <f:entry title="Host Named Pipes (newline-separated)" field="hostNamedPipes">
+        <f:expandableTextbox value="${dockerSwarmAgentTemplate.hostNamedPipes}"/>
+    </f:entry>
     <f:entry title="DNS IPs (newline-separated)" field="dnsIps">
         <f:expandableTextbox value="${dockerSwarmAgentTemplate.dnsIps}"/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/help-hostNamedPipes.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/help-hostNamedPipes.html
@@ -1,0 +1,3 @@
+<div>
+    <p>New line separated list of host named pipe mounts, valid only for Windows hosts: &lt;host/path&gt;:&lt;container/path&gt;</p>
+</div>


### PR DESCRIPTION
We use Swarm agents to build Docker container. In order for it to work in Windows, we need a new mount type : named pipes. 

`docker service create --name agent-test --mount type=npipe,source=\\\\.\\pipe\\docker_engine,destination=\\\\.\\pipe\\docker_engine docker_cli_image`

For this first version I added a new field in the configuration.