### PR TITLE
Allow spaces on envVars

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
@@ -127,7 +127,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
     }
 
     public String[] getEnvVarsConfig() {
-        return StringUtils.isEmpty(this.envVars) ? new String[] {} : this.envVars.split("[\\r\\n ]+");
+        return StringUtils.isEmpty(this.envVars) ? new String[] {} : this.envVars.split("[\\r\\n]+");
     }
 
     public String[] getCommandConfig() {


### PR DESCRIPTION
To allow environment variables with spaces the envVars string should only be split by EOL.

For example `JAVA_OPTS=-Dhttp.proxyHost=127.17.0.1 -Dhttp.proxyPort=8080`.