### PR TITLE
Fix a Google Charts issue related to JENKINS-49319

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/dashboard/UIPage/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/dashboard/UIPage/index.jelly
@@ -65,6 +65,10 @@
                 google.charts.load('current', {'packages':['corechart']});
                 google.charts.setOnLoadCallback(drawCharts);
                 function drawCharts() {
+                    // restore Array.prototype.entries native behaviour (see JENKINS-49319)
+                    Array.prototype.entries = function() {
+                        return Object.entries(this).map(([key,value]) => [+key, value])[Symbol.iterator]();
+                    }
                     drawCpuChart();
                     drawMemoryChart();
                 }


### PR DESCRIPTION
This fixes the issue of the charts not being drawn on the Docker Swarm Dashboard.

It restores the Array.prototype.entries native behaviour.

Prototype 1.7 pollutes Array.prototype.entries with a behaviour different to the native.
This behaviour is incompatible to what is expected by Google Charts.
The problem has been fixed on Prototype 1.7.3 but this version is not yet used by Jenkins (see JENKINS-49319).

This PR might need to be adjusted for compatibility with older browsers.