### PR TITLE
Fix getJobName() string sanitization

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
@@ -362,8 +362,7 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
     }
 
     public String getJobName() {
-        return this.jobName.replaceAll("/", "_").replaceAll("-", "_").replaceAll(",", "_").replaceAll(" ", "_")
-                .replaceAll("=", "_").replaceAll("\\.", "_");
+        return this.jobName.replaceAll("\\P{Alnum}", "_");
     }
 
 }


### PR DESCRIPTION
This fixes the name sanitization using a regex.
The regex will substitute all the characters that are not
alphanumerics (`\\P{}`) with a `_`.

This will avoid bugs when "Cache Dirs" volume names are generated.
For example, if a user has a Job inside a Folder the name will contain
the "»" character. This is now substituted along all the previous
characters.

The Docker error I had was:
```
create part_of_Bitbucket_Cloud_»_<redacted>_»_jenkins_agents_»_ubuntu18_<redacted>_#7-ubuntu18_<redacted>_7: "part_of_Bitbucket_Cloud_»_<redacted>_»_jenkins_agents_»_ubuntu18_<redacted>_#7-ubuntu18_<redacted>_7" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path
```
I assure the `<redacted>` parts are ascii characters only, unfortunately they are sensitive data I cannot display.

You can test this with the following Java snippet:
```java
class Scratch {
    public static void main(String[] args) {
        System.out.println("a/f,g.a!!!!3 33**/*ge»bbb#rr=".replaceAll("\\P{Alnum}", "_"));
    }
}
```