### PR TITLE
fix cacheVolumeName contain #

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
@@ -363,7 +363,8 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
 
     public String getJobName() {
         return this.jobName.replaceAll("/", "_").replaceAll("-", "_").replaceAll(",", "_").replaceAll(" ", "_")
-                .replaceAll("=", "_").replaceAll("\\.", "_");
+                .replaceAll("=", "_").replaceAll("\\.", "_")
+                .replaceAll("#","_").replaceAll("__","_");
     }
 
 }


### PR DESCRIPTION
create part_of_test_docker_swarm_#15-docker_swarm_15: "part_of_test_docker_swarm_#15-docker_swarm_15" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed