### PR TITLE
Fix AgentJnlpUrl due to JENKINS-35452

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
@@ -347,7 +347,7 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
     }
 
     private String getAgentJnlpUrl(final Computer computer, final DockerSwarmCloud configuration) {
-        return getJenkinsUrl(configuration) + computer.getUrl() + "slave-agent.jnlp";
+        return getJenkinsUrl(configuration) + computer.getUrl() + "jenkins-agent.jnlp";
 
     }
 


### PR DESCRIPTION
plugin is currently unable to spawn agents with jenkins v2.264 due to a change coming with JENKINS-35452