### PR TITLE
Added support for multiple labels

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
@@ -16,6 +16,8 @@ import hudson.model.Item;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 
+import java.util.Arrays;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTemplate> {
     private String tmpfsDir;
@@ -96,6 +98,10 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
 
     public String getLabel() {
         return this.label;
+    }
+
+    public String[] getLabels() {
+        return StringUtils.isEmpty(this.label) ? new String[]{} : this.label.split("\\s+");
     }
 
     public String getImage() {
@@ -274,4 +280,9 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
     public String getPullCredentialsId() {
         return pullCredentialsId;
     }
+
+    public boolean hasLabel(String label) {
+        return Arrays.asList(this.getLabels()).contains(label);
+    }
+
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -198,7 +199,7 @@ public class DockerSwarmCloud extends Cloud {
 
     public DockerSwarmAgentTemplate getLabelConfiguration(final String label) {
         for (final DockerSwarmAgentTemplate dockerSwarmAgentTemplate : this.agentTemplates) {
-            if (label.equals(dockerSwarmAgentTemplate.getLabel())) {
+            if (dockerSwarmAgentTemplate.hasLabel(label)) {
                 return dockerSwarmAgentTemplate;
             }
         }
@@ -206,8 +207,9 @@ public class DockerSwarmCloud extends Cloud {
     }
 
     public List<String> getLabels() {
-        final Iterable<String> labels = Iterables.transform(getAgentTemplates(),
-                dockerSwarmAgentTemplate -> dockerSwarmAgentTemplate.getLabel());
+        final Iterable<String> labels = Iterables.concat(
+                Iterables.transform(getAgentTemplates(),
+                        dockerSwarmAgentTemplate -> Arrays.asList(dockerSwarmAgentTemplate.getLabels())));
         return Lists.newArrayList(labels);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/dashboard/SwarmQueueItem.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/dashboard/SwarmQueueItem.java
@@ -53,10 +53,6 @@ public class SwarmQueueItem {
         return this.labelConfig;
     }
 
-    public String getLabelConfigLabel() {
-        return this.labelConfig.getLabel();
-    }
-
     public String getInQueueSince() {
         return this.inQueueSince;
     }

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form"
          xmlns:c="/lib/credentials">
-    <f:entry title="Label" field="label">
+    <f:entry title="Labels" field="label">
         <f:textbox value="${dockerSwarmAgentTemplate.label}" default="docker-agent"/>
     </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/help-label.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/help-label.html
@@ -1,6 +1,6 @@
 <div>
-    <p>Label for use by the "Restrict where this project can be run" configuration. e.g</p>
+    <p>Labels for use by the "Restrict where this project can be run" configuration. e.g</p>
     <code>
-docker-agent
+        docker-agent my-other-label
     </code>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/dashboard/UIPage/swarm-queue.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/dashboard/UIPage/swarm-queue.jelly
@@ -15,7 +15,7 @@
                 <ul class="list-unstyled">
                     <j:forEach items="${dbrd.queue}" var="item">
                         <li>
-                            <div class="p2">${item.name} (${item.labelConfigLabel})</div>
+                            <div class="p2">${item.name} (${item.label})</div>
                             <span class="p3">
                                 ${item.inQueueSince} - Provisioning:
                                 ${item.agentInfo.provisioningInProgress}


### PR DESCRIPTION
Not changed the way of storing and configuring the labels, but in logic uses a list of split "label" string by whitespaces. It's similar to working like other popular cloud plugins.

This closes #96 issue.