### PR TITLE
Multiple swarms

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/BuildScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/BuildScheduler.java
@@ -20,6 +20,7 @@ public class BuildScheduler {
     public static void scheduleBuild(final Queue.BuildableItem bi, final DockerSwarmCloud cloud) {
         try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
             final DockerSwarmLabelAssignmentAction action = createLabelAssignmentAction(bi.task.getDisplayName());
+            // TODO set cloud name on DockerSwarmAgentInfo ?
             DockerSwarmAgentInfo dockerSwarmAgentInfo = new DockerSwarmAgentInfo(true);
             dockerSwarmAgentInfo.setAgentLabel(action.getLabel().toString());
             bi.replaceAction(dockerSwarmAgentInfo);

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/BuildScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/BuildScheduler.java
@@ -20,7 +20,6 @@ public class BuildScheduler {
     public static void scheduleBuild(final Queue.BuildableItem bi, final DockerSwarmCloud cloud) {
         try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
             final DockerSwarmLabelAssignmentAction action = createLabelAssignmentAction(bi.task.getDisplayName());
-            // TODO set cloud name on DockerSwarmAgentInfo ?
             DockerSwarmAgentInfo dockerSwarmAgentInfo = new DockerSwarmAgentInfo(true);
             dockerSwarmAgentInfo.setAgentLabel(action.getLabel().toString());
             bi.replaceAction(dockerSwarmAgentInfo);

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/BuildScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/BuildScheduler.java
@@ -17,14 +17,14 @@ public class BuildScheduler {
     private static final Logger LOGGER = Logger.getLogger(BuildScheduler.class.getName());
     private static AtomicInteger counter = new AtomicInteger(1);
 
-    public static void scheduleBuild(final Queue.BuildableItem bi) {
+    public static void scheduleBuild(final Queue.BuildableItem bi, final DockerSwarmCloud cloud) {
         try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
             final DockerSwarmLabelAssignmentAction action = createLabelAssignmentAction(bi.task.getDisplayName());
             DockerSwarmAgentInfo dockerSwarmAgentInfo = new DockerSwarmAgentInfo(true);
             dockerSwarmAgentInfo.setAgentLabel(action.getLabel().toString());
             bi.replaceAction(dockerSwarmAgentInfo);
             bi.replaceAction(action);
-            final Node node = new DockerSwarmAgent(bi, action.getLabel().toString());
+            final Node node = new DockerSwarmAgent(bi, action.getLabel().toString(), cloud);
             Computer.threadPoolForRemoting.submit(() -> {
                 try {
                     Jenkins.getInstance().addNode(node); // locks queue

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DeadAgentServiceReaperActor.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DeadAgentServiceReaperActor.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import hudson.slaves.Cloud;
 import org.jenkinsci.plugins.docker.swarm.docker.api.response.ApiException;
 import org.jenkinsci.plugins.docker.swarm.docker.api.response.SerializationException;
 import org.jenkinsci.plugins.docker.swarm.docker.api.service.DeleteServiceRequest;
@@ -36,27 +37,28 @@ public class DeadAgentServiceReaperActor extends AbstractActor {
         try {
             final DockerSwarmPlugin swarmPlugin = Jenkins.getInstance().getPlugin(DockerSwarmPlugin.class);
             final ActorSystem as = swarmPlugin.getActorSystem();
-            if (DockerSwarmCloud.get() != null) {
-                String dockerSwarmApiUrl = DockerSwarmCloud.get().getDockerSwarmApiUrl();
-                final Object result = new ListServicesRequest(dockerSwarmApiUrl, "label", "ROLE=jenkins-agent").execute();
-                for (ScheduledService service : (List<ScheduledService>) getResult(result, List.class)) {
-                    Object tasks = new ListTasksRequest(dockerSwarmApiUrl, "service", service.Spec.Name).execute();
-                    if (tasks != null) {
-                        for (Task task : (List<Task>) getResult(tasks, List.class)) {
-                            if (task.isComplete()) {
-                                LOGGER.info("Reaping service: " + service.Spec.Name);
-                                new DeleteServiceRequest(dockerSwarmApiUrl, service.Spec.Name).execute();
-                                break;
+            for (Cloud cloud : Jenkins.getInstance().clouds) {
+                if (cloud instanceof DockerSwarmCloud) {
+                    final DockerSwarmCloud swarmCloud = (DockerSwarmCloud)cloud;
+                    String dockerSwarmApiUrl = swarmCloud.getDockerSwarmApiUrl();
+                    final Object result = new ListServicesRequest(dockerSwarmApiUrl, "label", "ROLE=jenkins-agent").execute();
+                    for (ScheduledService service : (List<ScheduledService>) getResult(result, List.class)) {
+                        Object tasks = new ListTasksRequest(dockerSwarmApiUrl, "service", service.Spec.Name).execute();
+                        if (tasks != null) {
+                            for (Task task : (List<Task>) getResult(tasks, List.class)) {
+                                if (task.isComplete()) {
+                                    LOGGER.info("Reaping service: " + service.Spec.Name);
+                                    new DeleteServiceRequest(dockerSwarmApiUrl, service.Spec.Name).execute();
+                                    break;
+                                }
                             }
                         }
                     }
-
                 }
             }
         } finally {
             reschedule();
         }
-
     }
 
     private <T> T getResult(Object result, Class<T> clazz) {

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DeadAgentServiceReaperActor.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DeadAgentServiceReaperActor.java
@@ -48,7 +48,7 @@ public class DeadAgentServiceReaperActor extends AbstractActor {
                             for (Task task : (List<Task>) getResult(tasks, List.class)) {
                                 if (task.isComplete()) {
                                     LOGGER.info("Reaping service: " + service.Spec.Name);
-                                    new DeleteServiceRequest(dockerSwarmApiUrl, service.Spec.Name).execute();
+                                    new DeleteServiceRequest(swarmCloud.name, service.Spec.Name).execute();
                                     break;
                                 }
                             }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
@@ -81,7 +81,7 @@ public class DockerSwarmAgent extends AbstractCloudSlave implements EphemeralNod
         try {
             DockerSwarmPlugin swarmPlugin = Jenkins.getInstance().getPlugin(DockerSwarmPlugin.class);
             ActorRef agentLauncherRef = swarmPlugin.getActorSystem().actorFor("/user/" + getComputer().getName());
-            agentLauncherRef.tell(new DeleteServiceRequest(getComputer().getName()), ActorRef.noSender());
+            agentLauncherRef.tell(new DeleteServiceRequest(getCloudName(), getComputer().getName()), ActorRef.noSender());
         } finally {
             try {
                 Jenkins.getInstance().removeNode(this);

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
@@ -25,8 +25,8 @@ public class DockerSwarmAgent extends AbstractCloudSlave implements EphemeralNod
 
     private static final Logger LOGGER = Logger.getLogger(DockerSwarmAgent.class.getName());
 
-    private final DockerSwarmAgentTemplate template;
     private final String cloudName;
+    private final String labelName;
 
     public DockerSwarmAgent(final Queue.BuildableItem bi, final String labelString, final DockerSwarmCloud cloud)
             throws Descriptor.FormException, IOException {
@@ -34,8 +34,8 @@ public class DockerSwarmAgent extends AbstractCloudSlave implements EphemeralNod
                 cloud.getLabelConfiguration(bi.task.getAssignedLabel().getName()).getWorkingDir(), 1,
                 Mode.EXCLUSIVE, labelString, new DockerSwarmComputerLauncher(bi, cloud),
                 new DockerSwarmAgentRetentionStrategy(1), Collections.emptyList());
-        final DockerSwarmAgentTemplate labelConfiguration = cloud.getLabelConfiguration(bi.task.getAssignedLabel().getName());
-        this.template = labelConfiguration;
+
+        this.labelName = bi.task.getAssignedLabel().getName();
         this.cloudName = cloud.name;
         LOGGER.log(Level.FINE, "Created docker swarm agent: {0}", labelString);
     }
@@ -49,7 +49,7 @@ public class DockerSwarmAgent extends AbstractCloudSlave implements EphemeralNod
     }
 
     public DockerSwarmAgentTemplate getTemplate() {
-        return template;
+        return ((DockerSwarmCloud)Jenkins.getInstance().clouds.getByName(cloudName)).getLabelConfiguration(labelName);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
@@ -26,16 +26,22 @@ public class DockerSwarmAgent extends AbstractCloudSlave implements EphemeralNod
     private static final Logger LOGGER = Logger.getLogger(DockerSwarmAgent.class.getName());
 
     private final DockerSwarmAgentTemplate template;
+    private final String cloudName;
 
     public DockerSwarmAgent(final Queue.BuildableItem bi, final String labelString, final DockerSwarmCloud cloud)
             throws Descriptor.FormException, IOException {
         super(labelString, "Docker swarm agent for building " + bi.task.getFullDisplayName(),
                 cloud.getLabelConfiguration(bi.task.getAssignedLabel().getName()).getWorkingDir(), 1,
-                Mode.EXCLUSIVE, labelString, new DockerSwarmComputerLauncher(bi),
+                Mode.EXCLUSIVE, labelString, new DockerSwarmComputerLauncher(bi, cloud),
                 new DockerSwarmAgentRetentionStrategy(1), Collections.emptyList());
         final DockerSwarmAgentTemplate labelConfiguration = cloud.getLabelConfiguration(bi.task.getAssignedLabel().getName());
         this.template = labelConfiguration;
+        this.cloudName = cloud.name;
         LOGGER.log(Level.FINE, "Created docker swarm agent: {0}", labelString);
+    }
+
+    public String getCloudName() {
+        return cloudName;
     }
 
     public DockerSwarmComputer createComputer() {

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
@@ -25,10 +25,10 @@ public class DockerSwarmAgent extends AbstractCloudSlave implements EphemeralNod
 
     private static final Logger LOGGER = Logger.getLogger(DockerSwarmAgent.class.getName());
 
-    public DockerSwarmAgent(final Queue.BuildableItem bi, final String labelString)
+    public DockerSwarmAgent(final Queue.BuildableItem bi, final String labelString, final DockerSwarmCloud cloud)
             throws Descriptor.FormException, IOException {
         super(labelString, "Docker swarm agent for building " + bi.task.getFullDisplayName(),
-                DockerSwarmCloud.get().getLabelConfiguration(bi.task.getAssignedLabel().getName()).getWorkingDir(), 1,
+                cloud.getLabelConfiguration(bi.task.getAssignedLabel().getName()).getWorkingDir(), 1,
                 Mode.EXCLUSIVE, labelString, new DockerSwarmComputerLauncher(bi),
                 new DockerSwarmAgentRetentionStrategy(1), Collections.emptyList());
         LOGGER.log(Level.FINE, "Created docker swarm agent: {0}", labelString);

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
@@ -25,17 +25,25 @@ public class DockerSwarmAgent extends AbstractCloudSlave implements EphemeralNod
 
     private static final Logger LOGGER = Logger.getLogger(DockerSwarmAgent.class.getName());
 
+    private final DockerSwarmAgentTemplate template;
+
     public DockerSwarmAgent(final Queue.BuildableItem bi, final String labelString, final DockerSwarmCloud cloud)
             throws Descriptor.FormException, IOException {
         super(labelString, "Docker swarm agent for building " + bi.task.getFullDisplayName(),
                 cloud.getLabelConfiguration(bi.task.getAssignedLabel().getName()).getWorkingDir(), 1,
                 Mode.EXCLUSIVE, labelString, new DockerSwarmComputerLauncher(bi),
                 new DockerSwarmAgentRetentionStrategy(1), Collections.emptyList());
+        final DockerSwarmAgentTemplate labelConfiguration = cloud.getLabelConfiguration(bi.task.getAssignedLabel().getName());
+        this.template = labelConfiguration;
         LOGGER.log(Level.FINE, "Created docker swarm agent: {0}", labelString);
     }
 
     public DockerSwarmComputer createComputer() {
         return new DockerSwarmComputer(this);
+    }
+
+    public DockerSwarmAgentTemplate getTemplate() {
+        return template;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentLauncherActor.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentLauncherActor.java
@@ -73,8 +73,8 @@ public class DockerSwarmAgentLauncherActor extends AbstractActor {
     }
 
     private void createService(ServiceSpec createRequest) throws IOException {
-        logger.println(String.format("[%s] Creating Service with Name : %s",
-                DateFormat.getTimeInstance().format(new Date()), createRequest.Name));
+        logger.println(String.format("[%s] Creating Service with Name : %s on swarm: %s",
+                DateFormat.getTimeInstance().format(new Date()), createRequest.Name, createRequest.SwarmName));
         this.createRequest = createRequest;
         handleServiceResponse(createRequest.execute());
     }
@@ -96,7 +96,7 @@ public class DockerSwarmAgentLauncherActor extends AbstractActor {
         if (StringUtils.isNotEmpty(createServiceResponse.Warning)) {
             logger.println("ServiceSpec creation warning : " + createServiceResponse.Warning);
         }
-        Object result = apiRequestWithErrorHandling(new ServiceLogRequest(createServiceResponse.ID));
+        Object result = apiRequestWithErrorHandling(new ServiceLogRequest(createRequest.SwarmName, createServiceResponse.ID));
         if (result instanceof ApiSuccess) {
             serviceLogResponse((ApiSuccess) result);
         }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
@@ -136,7 +136,7 @@ public class DockerSwarmCloud extends Cloud {
                 return FormValidation.error("URI must not have trailing /");
             }
             // FIXME DOES NOT WORK ANYMORE
-            Object response = new PingRequest(uri).execute();
+            Object response = new PingRequest(uri, credentialsId).execute();
             if (response instanceof ApiException) {
                 return FormValidation.error(((ApiException) response).getCause(),
                         "Couldn't ping docker api: " + uri + "/_ping");
@@ -152,7 +152,7 @@ public class DockerSwarmCloud extends Cloud {
         return dockerHost.getUri();
     }
 
-    private static SSLConfig toSSlConfig(String credentialsId) {
+    public static SSLConfig toSSlConfig(String credentialsId) {
         if (credentialsId == null)
             return null;
 

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
@@ -65,10 +65,10 @@ public class DockerSwarmCloud extends Cloud {
     private DockerServerEndpoint dockerHost;
 
     @DataBoundConstructor
-    public DockerSwarmCloud(DockerServerEndpoint dockerHost, String dockerSwarmApiUrl, String jenkinsUrl,
+    public DockerSwarmCloud(String name, DockerServerEndpoint dockerHost, String dockerSwarmApiUrl, String jenkinsUrl,
             String swarmNetwork, String cacheDriverName, String tunnel, List<DockerSwarmAgentTemplate> agentTemplates,
             long timeoutMinutes) {
-        super(DOCKER_SWARM_CLOUD_NAME);
+        super(name);
         this.jenkinsUrl = jenkinsUrl;
         this.swarmNetwork = swarmNetwork;
         this.cacheDriverName = cacheDriverName;

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
@@ -135,8 +135,9 @@ public class DockerSwarmCloud extends Cloud {
             if (uri.endsWith("/")) {
                 return FormValidation.error("URI must not have trailing /");
             }
-            // FIXME DOES NOT WORK ANYMORE
-            if(credentialsId.equals("")) { credentialsId = null; }
+            if(credentialsId.equals("")) {
+                credentialsId = null;
+            }
             Object response = new PingRequest(uri, credentialsId).execute();
             if (response instanceof ApiException) {
                 return FormValidation.error(((ApiException) response).getCause(),

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
@@ -136,6 +136,7 @@ public class DockerSwarmCloud extends Cloud {
                 return FormValidation.error("URI must not have trailing /");
             }
             // FIXME DOES NOT WORK ANYMORE
+            if(credentialsId.equals("")) { credentialsId = null; }
             Object response = new PingRequest(uri, credentialsId).execute();
             if (response instanceof ApiException) {
                 return FormValidation.error(((ApiException) response).getCause(),

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
@@ -135,6 +135,7 @@ public class DockerSwarmCloud extends Cloud {
             if (uri.endsWith("/")) {
                 return FormValidation.error("URI must not have trailing /");
             }
+            // FIXME DOES NOT WORK ANYMORE
             Object response = new PingRequest(uri).execute();
             if (response instanceof ApiException) {
                 return FormValidation.error(((ApiException) response).getCause(),

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud.java
@@ -211,8 +211,8 @@ public class DockerSwarmCloud extends Cloud {
         return Lists.newArrayList(labels);
     }
 
-    public static DockerSwarmCloud get() {
-        return (DockerSwarmCloud) Jenkins.getInstance().getCloud(DOCKER_SWARM_CLOUD_NAME);
+    public static DockerSwarmCloud get(String name) {
+        return (DockerSwarmCloud) Jenkins.getInstance().getCloud(name);
     }
 
     public void save() {
@@ -228,7 +228,7 @@ public class DockerSwarmCloud extends Cloud {
             ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
             try (InputStream in = new BufferedInputStream(new FileInputStream(swarmConfigYaml))) {
                 DockerSwarmCloud configuration = mapper.readValue(in, DockerSwarmCloud.class);
-                DockerSwarmCloud existingCloud = DockerSwarmCloud.get();
+                DockerSwarmCloud existingCloud = DockerSwarmCloud.get(configuration.name);
                 if (existingCloud != null) {
                     Jenkins.getInstance().clouds.remove(existingCloud);
                 }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
@@ -66,8 +66,14 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
     }
 
     private void launch(final DockerSwarmComputer computer, final TaskListener listener) throws IOException {
+        final DockerSwarmAgent agent = computer.getNode();
+
+        // FIXME get configuration from cloud name
         final DockerSwarmCloud configuration = DockerSwarmCloud.get();
-        final DockerSwarmAgentTemplate dockerSwarmAgentTemplate = configuration.getLabelConfiguration(this.label);
+        final DockerSwarmAgentTemplate dockerSwarmAgentTemplate = agent.getTemplate();
+        if(dockerSwarmAgentTemplate == null) {
+            throw new RuntimeException("dockerSwarmAgentTemplate is null");
+        }
 
         this.agentInfo = this.bi.getAction(DockerSwarmAgentInfo.class);
         this.agentInfo.setDockerImage(dockerSwarmAgentTemplate.getImage());

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
@@ -44,8 +44,8 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
 
     private static final Logger LOGGER = Logger.getLogger(DockerSwarmComputerLauncher.class.getName());
 
-    public DockerSwarmComputerLauncher(final Queue.BuildableItem bi) {
-        super(DockerSwarmCloud.get().getTunnel(), null, new RemotingWorkDirSettings(false, "/tmp", null, false));
+    public DockerSwarmComputerLauncher(final Queue.BuildableItem bi, final DockerSwarmCloud cloud) {
+        super(cloud.getTunnel(), null, new RemotingWorkDirSettings(false, "/tmp", null, false));
         this.bi = bi;
         this.label = bi.task.getAssignedLabel().getName();
         this.jobName = bi.task instanceof AbstractProject ? ((AbstractProject) bi.task).getFullName()
@@ -69,7 +69,7 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
         final DockerSwarmAgent agent = computer.getNode();
 
         // FIXME get configuration from cloud name
-        final DockerSwarmCloud configuration = DockerSwarmCloud.get();
+        final DockerSwarmCloud configuration = DockerSwarmCloud.get(agent.getCloudName());
         final DockerSwarmAgentTemplate dockerSwarmAgentTemplate = agent.getTemplate();
         if(dockerSwarmAgentTemplate == null) {
             throw new RuntimeException("dockerSwarmAgentTemplate is null");

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
@@ -136,8 +136,8 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
         setLimitsAndReservations(dockerSwarmAgentTemplate, crReq);
         setHostBinds(dockerSwarmAgentTemplate, crReq);
         setHostNamedPipes(dockerSwarmAgentTemplate, crReq);
-        setSecrets(dockerSwarmAgentTemplate, crReq);
-        setConfigs(dockerSwarmAgentTemplate, crReq);
+        setSecrets(configuration.name, dockerSwarmAgentTemplate, crReq);
+        setConfigs(configuration.name, dockerSwarmAgentTemplate, crReq);
         setNetwork(configuration, crReq);
         setCacheDirs(configuration, dockerSwarmAgentTemplate, listener, computer, crReq);
         setTmpfs(dockerSwarmAgentTemplate, crReq);
@@ -180,9 +180,9 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
                     : String.format("docker run --rm --privileged --network %s %s sh -xc '%s' ",
                             configuration.getSwarmNetwork(), dockerSwarmAgentTemplate.getImage(), commands[2]);
 
-            crReq = new ServiceSpec(computer.getName(), "docker:17.12", commands, envVars, dir, user, hosts);
+            crReq = new ServiceSpec(configuration.name, computer.getName(), "docker:17.12", commands, envVars, dir, user, hosts);
         } else {
-            crReq = new ServiceSpec(computer.getName(), dockerSwarmAgentTemplate.getImage(), commands, envVars, dir,
+            crReq = new ServiceSpec(configuration.name, computer.getName(), dockerSwarmAgentTemplate.getImage(), commands, envVars, dir,
                     user, hosts);
         }
         return crReq;
@@ -235,11 +235,11 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
         }
     }
 
-    private void setSecrets(DockerSwarmAgentTemplate dockerSwarmAgentTemplate, ServiceSpec crReq) {
+    private void setSecrets(String swarmName, DockerSwarmAgentTemplate dockerSwarmAgentTemplate, ServiceSpec crReq) {
         String[] secrets = dockerSwarmAgentTemplate.getSecretsConfig();
         if (secrets.length > 0)
             try {
-                final Object secretList = new ListSecretsRequest().execute();
+                final Object secretList = new ListSecretsRequest(swarmName).execute();
                 for (int i = 0; i < secrets.length; i++) {
                     String secret = secrets[i];
                     String[] split = secret.split(":");
@@ -260,11 +260,11 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
             }
     }
 
-    private void setConfigs(DockerSwarmAgentTemplate dockerSwarmAgentTemplate, ServiceSpec crReq) {
+    private void setConfigs(String swarmName, DockerSwarmAgentTemplate dockerSwarmAgentTemplate, ServiceSpec crReq) {
         String[] configs = dockerSwarmAgentTemplate.getConfigsConfig();
         if (configs.length > 0)
             try {
-                final Object configList = new ListConfigsRequest().execute();
+                final Object configList = new ListConfigsRequest(swarmName).execute();
                 for (int i = 0; i < configs.length; i++) {
                     String config = configs[i];
                     String[] split = config.split(":");

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
@@ -68,7 +68,6 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
     private void launch(final DockerSwarmComputer computer, final TaskListener listener) throws IOException {
         final DockerSwarmAgent agent = computer.getNode();
 
-        // FIXME get configuration from cloud name
         final DockerSwarmCloud configuration = DockerSwarmCloud.get(agent.getCloudName());
         final DockerSwarmAgentTemplate dockerSwarmAgentTemplate = agent.getTemplate();
         if(dockerSwarmAgentTemplate == null) {

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/OneShotProvisionQueueListener.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/OneShotProvisionQueueListener.java
@@ -7,9 +7,11 @@ import java.util.logging.Logger;
 
 import hudson.Extension;
 import hudson.model.Computer;
+import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.queue.QueueListener;
+import hudson.slaves.Cloud;
 import jenkins.model.Jenkins;
 
 @Extension
@@ -20,9 +22,10 @@ public class OneShotProvisionQueueListener extends QueueListener {
     @Override
     public void onEnterBuildable(final Queue.BuildableItem bi) {
         final Queue.Task job = bi.task;
-        if (DockerSwarmCloud.get() != null) {
-            final List<String> labels = DockerSwarmCloud.get().getLabels();
-            if (job.getAssignedLabel() != null && labels.contains(job.getAssignedLabel().getName())) {
+        final Jenkins jenkins = Jenkins.getInstance();
+        final Label label = bi.getAssignedLabel();
+        for (Cloud cloud : jenkins.clouds) {
+            if (cloud instanceof DockerSwarmCloud && cloud.canProvision(label)) {
                 BuildScheduler.scheduleBuild(bi);
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/OneShotProvisionQueueListener.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/OneShotProvisionQueueListener.java
@@ -21,12 +21,12 @@ public class OneShotProvisionQueueListener extends QueueListener {
 
     @Override
     public void onEnterBuildable(final Queue.BuildableItem bi) {
-        final Queue.Task job = bi.task;
         final Jenkins jenkins = Jenkins.getInstance();
         final Label label = bi.getAssignedLabel();
         for (Cloud cloud : jenkins.clouds) {
             if (cloud instanceof DockerSwarmCloud && cloud.canProvision(label)) {
-                BuildScheduler.scheduleBuild(bi);
+                BuildScheduler.scheduleBuild(bi, (DockerSwarmCloud)cloud);
+                break;
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/ResetStuckBuildsInQueueActor.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/ResetStuckBuildsInQueueActor.java
@@ -34,7 +34,15 @@ public class ResetStuckBuildsInQueueActor extends AbstractActor {
 
     private void resetStuckBuildsInQueue() throws IOException {
         try {
-            long resetMinutes = Optional.ofNullable(DockerSwarmCloud.get().getTimeoutMinutes()).orElse(DEFAULT_RESET_MINUTES);
+            //FIXME getting timeout from first cloud
+            DockerSwarmCloud swarmCloud = null;
+            for (final Cloud cloud: Jenkins.getInstance().clouds) {
+                if(cloud instanceof DockerSwarmCloud) {
+                    swarmCloud = (DockerSwarmCloud)cloud;
+                    break;
+                }
+            }
+            long resetMinutes = Optional.ofNullable(swarmCloud.getTimeoutMinutes()).orElse(DEFAULT_RESET_MINUTES);
             final Queue.Item[] items = Jenkins.getInstance().getQueue().getItems();
             for (int i = items.length - 1; i >= 0; i--) { // reverse order
                 final Queue.Item item = items[i];

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/dashboard/Dashboard.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/dashboard/Dashboard.java
@@ -12,7 +12,9 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.Iterables;
 
+import hudson.slaves.Cloud;
 import org.jenkinsci.plugins.docker.swarm.DockerSwarmAgentInfo;
+import org.jenkinsci.plugins.docker.swarm.DockerSwarmCloud;
 import org.jenkinsci.plugins.docker.swarm.Util;
 import org.jenkinsci.plugins.docker.swarm.docker.api.nodes.ListNodesRequest;
 import org.jenkinsci.plugins.docker.swarm.docker.api.nodes.Node;
@@ -36,6 +38,12 @@ public class Dashboard {
     private String swarmName;
 
     public Dashboard() throws IOException {
+        for( final Cloud cloud: Jenkins.getInstance().clouds){
+            if (cloud instanceof  DockerSwarmCloud) {
+                swarmName = cloud.name;
+                break;
+            }
+        }
         this.nodes = calculateNodes();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/dashboard/Dashboard.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/dashboard/Dashboard.java
@@ -32,6 +32,8 @@ import net.sf.json.JSONArray;
 public class Dashboard {
     private final List<SwarmNode> nodes;
 
+    private String swarmName;
+
     public Dashboard() throws IOException {
         this.nodes = calculateNodes();
     }
@@ -43,7 +45,7 @@ public class Dashboard {
             final Queue.Item item = items[i];
             final DockerSwarmAgentInfo agentInfo = item.getAction(DockerSwarmAgentInfo.class);
             if (agentInfo != null && item instanceof Queue.BuildableItem) {
-                queue.add(new SwarmQueueItem((Queue.BuildableItem) item));
+                queue.add(new SwarmQueueItem((Queue.BuildableItem) item, swarmName));
             }
         }
         return queue;

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/dashboard/Dashboard.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/dashboard/Dashboard.java
@@ -32,6 +32,7 @@ import net.sf.json.JSONArray;
 public class Dashboard {
     private final List<SwarmNode> nodes;
 
+    // FIXME to be set somewher
     private String swarmName;
 
     public Dashboard() throws IOException {
@@ -130,9 +131,9 @@ public class Dashboard {
     }
 
     private List<SwarmNode> calculateNodes() throws IOException {
-        final List<Node> nodeList = getResult(new ListNodesRequest().execute(), List.class);
-        final List services = getResult(new ListServicesRequest().execute(), List.class);
-        final Object tasks = new ListTasksRequest().execute();
+        final List<Node> nodeList = getResult(new ListNodesRequest(swarmName).execute(), List.class);
+        final List services = getResult(new ListServicesRequest(swarmName).execute(), List.class);
+        final Object tasks = new ListTasksRequest(swarmName).execute();
         return toSwarmNodes(services, getResult(tasks, List.class), nodeList);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/dashboard/SwarmQueueItem.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/dashboard/SwarmQueueItem.java
@@ -18,10 +18,10 @@ public class SwarmQueueItem {
     private final DockerSwarmAgentInfo agentInfo;
     private Computer provisionedComputer;
 
-    public SwarmQueueItem(final Queue.BuildableItem item) {
+    public SwarmQueueItem(final Queue.BuildableItem item, final String swarmName) {
         this.name = item.task.getFullDisplayName();
         this.label = item.task.getAssignedLabel().getName();
-        this.labelConfig = DockerSwarmCloud.get().getLabelConfiguration(this.label);
+        this.labelConfig = DockerSwarmCloud.get(swarmName).getLabelConfiguration(this.label);
         this.inQueueSince = item.getInQueueForString();
         this.agentInfo = item.getAction(DockerSwarmAgentInfo.class); // this should never be null
 

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/configs/ListConfigsRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/configs/ListConfigsRequest.java
@@ -10,19 +10,15 @@ import org.jenkinsci.plugins.docker.swarm.docker.marshalling.ResponseType;
 
 public class ListConfigsRequest extends ApiRequest {
 
-    public ListConfigsRequest(String url) throws IOException {
-        super(HttpMethod.GET, url, Config.class, ResponseType.LIST);
+    public ListConfigsRequest(String swarmName, String url) throws IOException {
+        super(swarmName, HttpMethod.GET, url, ScheduledService.class, ResponseType.LIST, null);
     }
 
-    public ListConfigsRequest(String dockerApiUrl, String url) throws IOException {
-        super(HttpMethod.GET, dockerApiUrl, url, ScheduledService.class, ResponseType.LIST, null);
+    public ListConfigsRequest(String swarmName) throws IOException {
+        this(swarmName, "/configs");
     }
 
-    public ListConfigsRequest() throws IOException {
-        this("/configs");
-    }
-
-    public ListConfigsRequest(String dockerApiUrl, String filterKey, String filterValue) throws IOException {
-        this(dockerApiUrl, "/configs?filters=" + encodeJsonFilter(filterKey, filterValue));
+    public ListConfigsRequest(String swarmName, String filterKey, String filterValue) throws IOException {
+        this(swarmName, "/configs?filters=" + encodeJsonFilter(filterKey, filterValue));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/nodes/ListNodesRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/nodes/ListNodesRequest.java
@@ -9,11 +9,7 @@ import org.jenkinsci.plugins.docker.swarm.docker.marshalling.ResponseType;
 
 public class ListNodesRequest extends ApiRequest {
 
-    public ListNodesRequest() throws IOException {
-        super(HttpMethod.GET, "/nodes", Node.class, ResponseType.LIST);
-    }
-
-    public ListNodesRequest(String dockerSwarmApiUrl) throws IOException {
-        super(HttpMethod.GET, dockerSwarmApiUrl, "/nodes", Node.class, ResponseType.LIST, null);
+    public ListNodesRequest(final String swarmName) throws IOException {
+        super(swarmName, HttpMethod.GET, "/nodes", Node.class, ResponseType.LIST);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/ping/PingRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/ping/PingRequest.java
@@ -6,7 +6,7 @@ import org.jenkinsci.plugins.docker.swarm.docker.api.HttpMethod;
 import org.jenkinsci.plugins.docker.swarm.docker.api.request.ApiRequest;
 
 public class PingRequest extends ApiRequest {
-    public PingRequest(String swarmName) throws IOException {
-        super(swarmName, HttpMethod.GET, "/_ping", null, null, null);
+    public PingRequest(String uri, String credentialsId) throws IOException {
+        super(HttpMethod.GET, uri,"/_ping", null, null, null, credentialsId);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/ping/PingRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/ping/PingRequest.java
@@ -6,7 +6,7 @@ import org.jenkinsci.plugins.docker.swarm.docker.api.HttpMethod;
 import org.jenkinsci.plugins.docker.swarm.docker.api.request.ApiRequest;
 
 public class PingRequest extends ApiRequest {
-    public PingRequest(String dockerApiUrl) throws IOException {
-        super(HttpMethod.GET, dockerApiUrl, "/_ping", null, null, null);
+    public PingRequest(String swarmName) throws IOException {
+        super(swarmName, HttpMethod.GET, "/_ping", null, null, null);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/request/ApiRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/request/ApiRequest.java
@@ -90,6 +90,9 @@ public abstract class ApiRequest {
     }
 
     private static String getDockerUriFromSwarmName (String swarmName) {
+        if(swarmName == null) {
+            return null;
+        }
         final DockerSwarmCloud swarmCloud = DockerSwarmCloud.get(swarmName);
         if (swarmCloud.getDockerHost() != null) {
             return swarmCloud.getDockerHost().getUri();
@@ -99,6 +102,9 @@ public abstract class ApiRequest {
     }
 
     private  static final String dockerCredentialsIdFromSwarmName(String swarmName){
+        if(swarmName == null) {
+            return null;
+        }
         final DockerSwarmCloud swarmCloud = DockerSwarmCloud.get(swarmName);
         if (swarmCloud.getDockerHost() != null) {
             return swarmCloud.getDockerHost().getCredentialsId();

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/secrets/ListSecretsRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/secrets/ListSecretsRequest.java
@@ -9,20 +9,15 @@ import org.jenkinsci.plugins.docker.swarm.docker.api.service.ScheduledService;
 import org.jenkinsci.plugins.docker.swarm.docker.marshalling.ResponseType;
 
 public class ListSecretsRequest extends ApiRequest {
-
-    public ListSecretsRequest(String url) throws IOException {
-        super(HttpMethod.GET, url, Secret.class, ResponseType.LIST);
+    public ListSecretsRequest(String swarmName, String url) throws IOException {
+        super(swarmName, HttpMethod.GET, url, ScheduledService.class, ResponseType.LIST, null);
     }
 
-    public ListSecretsRequest(String dockerApiUrl, String url) throws IOException {
-        super(HttpMethod.GET, dockerApiUrl, url, ScheduledService.class, ResponseType.LIST, null);
+    public ListSecretsRequest(String swarmName) throws IOException {
+        this(swarmName, "/secrets");
     }
 
-    public ListSecretsRequest() throws IOException {
-        this("/secrets");
-    }
-
-    public ListSecretsRequest(String dockerApiUrl, String filterKey, String filterValue) throws IOException {
-        this(dockerApiUrl, "/secrets?filters=" + encodeJsonFilter(filterKey, filterValue));
+    public ListSecretsRequest(String swarmName, String filterKey, String filterValue) throws IOException {
+        this(swarmName, "/secrets?filters=" + encodeJsonFilter(filterKey, filterValue));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/service/DeleteServiceRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/service/DeleteServiceRequest.java
@@ -6,12 +6,7 @@ import org.jenkinsci.plugins.docker.swarm.docker.api.HttpMethod;
 import org.jenkinsci.plugins.docker.swarm.docker.api.request.ApiRequest;
 
 public class DeleteServiceRequest extends ApiRequest {
-    public DeleteServiceRequest(String serviceName) throws IOException {
-        super(HttpMethod.DELETE, "/services/" + serviceName);
+    public DeleteServiceRequest(String swarmName, String serviceName) throws IOException {
+        super(swarmName, HttpMethod.DELETE, "/services/" + serviceName);
     }
-
-    public DeleteServiceRequest(String dockerApiUrl, String serviceName) throws IOException {
-        super(HttpMethod.DELETE, dockerApiUrl, "/services/" + serviceName, null, null, null);
-    }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/service/ListServicesRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/service/ListServicesRequest.java
@@ -8,20 +8,15 @@ import org.jenkinsci.plugins.docker.swarm.docker.api.request.ApiRequest;
 import org.jenkinsci.plugins.docker.swarm.docker.marshalling.ResponseType;
 
 public class ListServicesRequest extends ApiRequest {
-
-    public ListServicesRequest(String url) throws IOException {
-        super(HttpMethod.GET, url, ScheduledService.class, ResponseType.LIST);
+    public ListServicesRequest(String swarmName, String url) throws IOException {
+        super(swarmName, HttpMethod.GET, url, ScheduledService.class, ResponseType.LIST, null);
     }
 
-    public ListServicesRequest(String dockerApiUrl, String url) throws IOException {
-        super(HttpMethod.GET, dockerApiUrl, url, ScheduledService.class, ResponseType.LIST, null);
+    public ListServicesRequest(String swarmName) throws IOException {
+        this(swarmName, "/services");
     }
 
-    public ListServicesRequest() throws IOException {
-        this("/services");
-    }
-
-    public ListServicesRequest(String dockerApiUrl, String filterKey, String filterValue) throws IOException {
-        this(dockerApiUrl, "/services?filters=" + encodeJsonFilter(filterKey, filterValue));
+    public ListServicesRequest(String swarmName, String filterKey, String filterValue) throws IOException {
+        this(swarmName, "/services?filters=" + encodeJsonFilter(filterKey, filterValue));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/service/ServiceLogRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/service/ServiceLogRequest.java
@@ -7,7 +7,7 @@ import org.jenkinsci.plugins.docker.swarm.docker.api.request.ApiRequest;
 
 public class ServiceLogRequest extends ApiRequest {
 
-    public ServiceLogRequest(String id) throws IOException {
-        super(HttpMethod.GET, "/services/" + id + "/logs?follow=true&stdout=true&stderr=true");
+    public ServiceLogRequest(String swarmName, String id) throws IOException {
+        super(swarmName, HttpMethod.GET, "/services/" + id + "/logs?follow=true&stdout=true&stderr=true");
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/service/ServiceSpec.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/service/ServiceSpec.java
@@ -38,8 +38,9 @@ public class ServiceSpec extends ApiRequest {
         this.EndpointSpec = new EndpointSpec();
     }
 
-    public ServiceSpec(String swarmName) throws IOException {
-        super(swarmName, HttpMethod.POST, "/services/create", CreateServiceResponse.class, ResponseType.CLASS, null);
+    // default constructor to deserialize JSON from the dashboard page
+    public ServiceSpec() throws IOException {
+        super(null, HttpMethod.POST, "/services/create", CreateServiceResponse.class, ResponseType.CLASS, null);
     }
 
     public void addBindVolume(String source, String target) {

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/service/ServiceSpec.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/service/ServiceSpec.java
@@ -24,20 +24,22 @@ public class ServiceSpec extends ApiRequest {
     public org.jenkinsci.plugins.docker.swarm.docker.api.task.TaskTemplate TaskTemplate;
     public org.jenkinsci.plugins.docker.swarm.docker.api.network.EndpointSpec EndpointSpec;
     public String Name;
+    public String SwarmName;
     public Map<String, String> Labels = new HashMap<>();
 
     public List<Network> Networks = new ArrayList<>();
 
-    public ServiceSpec(String name, String Image, String[] Cmd, String[] Env, String Dir, String User, String[] Hosts)
+    public ServiceSpec(String swarmName, String name, String Image, String[] Cmd, String[] Env, String Dir, String User, String[] Hosts)
             throws IOException {
-        super(HttpMethod.POST, "/services/create", CreateServiceResponse.class, ResponseType.CLASS);
+        super(swarmName, HttpMethod.POST, "/services/create", CreateServiceResponse.class, ResponseType.CLASS);
+        this.SwarmName = swarmName;
         this.Name = name;
         this.TaskTemplate = new TaskTemplate(Image, Cmd, Env, Dir, User, Hosts);
         this.EndpointSpec = new EndpointSpec();
     }
 
-    public ServiceSpec() throws IOException {
-        super(HttpMethod.POST, "", "/services/create", CreateServiceResponse.class, ResponseType.CLASS, null);
+    public ServiceSpec(String swarmName) throws IOException {
+        super(swarmName, HttpMethod.POST, "/services/create", CreateServiceResponse.class, ResponseType.CLASS, null);
     }
 
     public void addBindVolume(String source, String target) {

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/task/ListTasksRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/docker/api/task/ListTasksRequest.java
@@ -9,15 +9,15 @@ import org.jenkinsci.plugins.docker.swarm.docker.marshalling.ResponseType;
 
 public class ListTasksRequest extends ApiRequest {
 
-    public ListTasksRequest() throws IOException {
-        super(HttpMethod.GET, "/tasks", Task.class, ResponseType.LIST);
+    public ListTasksRequest(String swarmName) throws IOException {
+        super(swarmName, HttpMethod.GET, "/tasks", Task.class, ResponseType.LIST);
     }
 
-    public ListTasksRequest(String dockerSwarmApiUrl, String url) throws IOException {
-        super(HttpMethod.GET, dockerSwarmApiUrl, url, Task.class, ResponseType.LIST, null);
+    public ListTasksRequest(String swarmName, String url) throws IOException {
+        super(swarmName, HttpMethod.GET, url, Task.class, ResponseType.LIST, null);
     }
 
-    public ListTasksRequest(String dockerApiUrl, String filterKey, String filterValue) throws IOException {
-        this(dockerApiUrl, "/tasks?filters=" + encodeJsonFilter(filterKey, filterValue));
+    public ListTasksRequest(String swarmName, String filterKey, String filterValue) throws IOException {
+        this(swarmName, "/tasks?filters=" + encodeJsonFilter(filterKey, filterValue));
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud/config.jelly
@@ -5,6 +5,9 @@
     <f:section title="Docker Swarm Cloud Configuration">
         <f:property field="dockerHost"/>
         <f:validateButton method="validateTestDockerApiConnection" title="Test Connection" with="uri,credentialsId"/>
+        <f:entry title="Swarm name " field="name">
+            <f:textbox/>
+        </f:entry>
         <f:entry title="Jenkins Url " field="jenkinsUrl">
             <f:textbox/>
         </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud/help-name.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud/help-name.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Uniquely identifies this Cloud instance among other instances in Jenkins Clouds. This is expected to be short ID-like string that does not contain any character unsafe as variable name or URL path token.</p>
+</div>


### PR DESCRIPTION
Working on #90
Currently the plugin seems to consider the Docker Swarm cloud as a singleton, so there are several places in the code that would need to be changed to work with a list of items, instead of a single default one.

* ApiRequest changed to take SwarmName as a parameter, to get both Docker host URI and configured CredentialsId
* Only PingRequest does not provide a SwarmName, since it is used before saving the configuration
* DockerSwarmCloud.get() has been changed to take a swarm name parameter, so all code relying on this singleton has been modified to handle multiple swarms
* Code managing dynamic nodes has been changed too, and needs some cleanup
* The dashboard page kind of works but only displays the first swarm found, for now