### PR TITLE
Be able to add label to created service

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
@@ -38,6 +38,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
     private String command;
     private String user;
     private String workingDir;
+    private String metadata;
     private String hosts;
 
     private String cacheDir;
@@ -57,7 +58,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
     @DataBoundConstructor
     public DockerSwarmAgentTemplate(final String image, final String hostBinds, final String hostNamedPipes, final String dnsIps,
             final String dnsSearchDomains, final String command, final String user, final String workingDir,
-            final String hosts, final String secrets, final String configs, final String label, final String cacheDir,
+            final String hosts, final String metadata, final String secrets, final String configs, final String label, final String cacheDir,
             final String tmpfsDir, final String envVars, final long limitsNanoCPUs, final long limitsMemoryBytes,
             final long reservationsNanoCPUs, final long reservationsMemoryBytes, String portBinds, final boolean osWindows,
             final String baseWorkspaceLocation, final String placementConstraints, final String placementArchitecture,
@@ -71,6 +72,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
         this.user = user;
         this.workingDir = workingDir;
         this.hosts = hosts;
+        this.metadata = metadata;
         this.secrets = secrets;
         this.configs = configs;
         this.label = label;
@@ -110,6 +112,10 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
 
     public String[] getHostBindsConfig() {
         return StringUtils.isEmpty(this.hostBinds) ? new String[] {} : this.hostBinds.split("[\\r\\n ]+");
+    }
+
+    public String[] getMetadataConfig() {
+        return StringUtils.isEmpty(this.metadata) ? new String[] {} : this.metadata.split("[\\r\\n ]+");
     }
 
     public String[] getHostNamedPipesConfig() {
@@ -232,6 +238,8 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
     public String getHostBinds() {
         return hostBinds;
     }
+
+    public String getMetadata() { return metadata; }
 
     public String getHostNamedPipes() {
         return hostNamedPipes;

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
@@ -142,6 +142,7 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
         setDnsIps(dockerSwarmAgentTemplate, crReq);
         setDnsSearchDomains(dockerSwarmAgentTemplate, crReq);
         setPortBinds(dockerSwarmAgentTemplate, crReq);
+        setMetadata(dockerSwarmAgentTemplate, crReq);
 
         this.agentInfo.setServiceRequestJson(crReq.toJsonString());
 
@@ -307,6 +308,19 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
         String[] dnsSearchDomains = dockerSwarmAgentTemplate.getDnsSearchDomainsConfig();
         for (String dnsSearchDomain : dnsSearchDomains) {
             crReq.addDnsSearchDomain(dnsSearchDomain);
+        }
+    }
+
+    private void setMetadata(DockerSwarmAgentTemplate dockerSwarmAgentTemplate, ServiceSpec crReq) {
+        String[] metadata = dockerSwarmAgentTemplate.getMetadataConfig();
+        for(String mt : metadata) {
+            if (!mt.contains("=")) {
+                continue;
+            }
+            String[] metadataRecord = mt.split("=");
+            if (metadataRecord.length == 2) {
+                crReq.addLabel(metadataRecord[0], metadataRecord[1]);
+            }
         }
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
@@ -18,6 +18,9 @@
     <f:entry title="User" field="user">
         <f:textbox value="${dockerSwarmAgentTemplate.user}"/>
     </f:entry>
+    <f:entry title="Metadata (newline-separated)" field="metadata">
+        <f:expandableTextbox value="${dockerSwarmAgentTemplate.metadata}"/>
+    </f:entry>
     <f:entry title="Env (newline-separated)" field="envVars">
         <f:expandableTextbox value="${dockerSwarmAgentTemplate.envVars}"/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/help-metadata.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/help-metadata.html
@@ -1,0 +1,7 @@
+<div>
+    <p>Configure metadata for container (labels)</p>
+    <code>
+        &lt;key&gt;=&lt;value&gt;</br>
+        com.example.foo=bar2
+    </code>
+</div>


### PR DESCRIPTION
We are using docker-swarm-plugin as provider for slave. Unfortunately we are facing connectivity problems in swarm and it happens that there remains running containers or dead services (without replicas) when jenkins job is killed or connection is reset. Because of that we would like to be able to define label (e.g. marker how long service shoul live, TTL=24H, TTL=48H etc) in a docker agent template configuration. Based on that labels we will be able to clean up running services without affecting correctly startup services.

Configuration:
![obrazek](https://user-images.githubusercontent.com/7419456/134953029-85e7b689-2a10-4212-b44e-6dfd6833edb5.png)


Result service:
`[
    {
        "ID": "sm1eitmz1ypuorjo43c8hesz0",
        "Version": {
            "Index": 67228061
        },
        "CreatedAt": "2021-09-27T16:46:22.040470091Z",
        "UpdatedAt": "2021-09-27T16:46:22.096417534Z",
        "Spec": {
            "Name": "agt-test_drimalm-4",
            "Labels": {
                "ROLE": "jenkins-agent",
                "TTL": "48H",
                "TEAM": "TeamA"
            },`

- [ X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X ] Ensure that the pull request title represents the desired changelog entry
- [X ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
