### PR TITLE
Prevent premature removal of agent when Jenkins is in quiet mode

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentRetentionStrategy.java
@@ -19,6 +19,7 @@ import hudson.model.Executor;
 import hudson.model.ExecutorListener;
 import hudson.model.Queue;
 import hudson.slaves.RetentionStrategy;
+import jenkins.model.Jenkins;
 
 public class DockerSwarmAgentRetentionStrategy extends RetentionStrategy<DockerSwarmComputer>
         implements ExecutorListener {
@@ -45,7 +46,7 @@ public class DockerSwarmAgentRetentionStrategy extends RetentionStrategy<DockerS
             final long connectTime = System.currentTimeMillis() - c.getConnectTime();
             final long idleTime = System.currentTimeMillis() - c.getIdleStartMilliseconds();
             final boolean isTimeout = connectTime > timeout && idleTime > timeout;
-            if (isTimeout && (!isTaskAccepted || isTaskCompleted)) {
+            if (isTimeout && (!isTaskAccepted || isTaskCompleted ) && !Jenkins.getInstance().isQuietingDown()) {
                 LOGGER.log(Level.INFO, "Disconnecting due to idle {0}", c.getName());
                 done(c);
             }


### PR DESCRIPTION
Issue:  https://github.com/jenkinsci/docker-swarm-plugin/issues/113

<!-- Please describe your pull request here. -->

When Jenkins is in quiet/prepare for shudown mode, new builds will cause an agent to be instantiated.  The retention strategy code will remove the agent within 2-3 minutes.  Added a check to see if Jenkins is in quiet mode and if it is, don't check again until the next audit (1 minute in the code).

To test.  
- Put Jenkins in "shutdown" mode
- Schedule a build which uses an agent
- Without the fix, the agent eventually gets removed.  When you cancel shutdown, the build will be stuck waiting for an agent indefinitely
- With the fix, there will be an agent spawned to run the build and it will start as soon as the shutdown is cancelled

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue (Not in code, but description

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
