### PR TITLE
Prevent premature removal of agent because of race condition in DockerSwarmAgentRetentionStrategy

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentRetentionStrategy.java
@@ -43,8 +43,9 @@ public class DockerSwarmAgentRetentionStrategy extends RetentionStrategy<DockerS
     public long check(@Nonnull DockerSwarmComputer c) {
         if (c.isIdle() && c.isOnline()) {
             final long connectTime = System.currentTimeMillis() - c.getConnectTime();
+            final long onlineTime = System.currentTimeMillis() - c.getOnlineTime();
             final long idleTime = System.currentTimeMillis() - c.getIdleStartMilliseconds();
-            final boolean isTimeout = connectTime > timeout && idleTime > timeout;
+            final boolean isTimeout = connectTime > timeout && onlineTime > timeout && idleTime > timeout;
             if (isTimeout && (!isTaskAccepted || isTaskCompleted)) {
                 LOGGER.log(Level.INFO, "Disconnecting due to idle {0}", c.getName());
                 done(c);

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputer.java
@@ -1,19 +1,29 @@
 
 package org.jenkinsci.plugins.docker.swarm;
 
+import java.io.IOException;
+import java.io.OutputStream;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.google.common.collect.Iterables;
 
 import hudson.model.Executor;
 import hudson.model.Queue;
+import hudson.remoting.Channel;
+import hudson.remoting.Channel.Listener;
 import hudson.slaves.AbstractCloudComputer;
 import hudson.slaves.OfflineCause;
 
 public class DockerSwarmComputer extends AbstractCloudComputer<DockerSwarmAgent> {
+    private static final Logger LOGGER = Logger.getLogger(DockerSwarmComputer.class.getName());
+
+    private long onlineTime = 0L;
 
     public DockerSwarmComputer(final DockerSwarmAgent dockerSwarmAgent) {
         super(dockerSwarmAgent);
@@ -54,5 +64,18 @@ public class DockerSwarmComputer extends AbstractCloudComputer<DockerSwarmAgent>
 
     public String getVolumeName() {
         return getName().split("-")[1];
+    }
+
+    public final long getOnlineTime() {
+        return onlineTime;
+    }
+
+    @Override
+    public void setChannel(Channel channel, OutputStream launchLog, Listener listener) throws IOException, InterruptedException {
+        this.onlineTime = System.currentTimeMillis();
+
+        super.setChannel(channel, launchLog, listener);
+
+        LOGGER.log(Level.INFO, "Agent {0} got online", getName());
     }
 }


### PR DESCRIPTION
This fixes the problem of agents being removed too early by the Swarm Plugin due to a race condition which can happen in the DockerSwarmAgentRetentionStrategy class.

It can happen that an agent (Docker container) cannot start immediately after creation by the Swarm Plugin - possibly due to a lack of free resources in the Docker swarm - and therefore the agent comes online late, maybe one or several minutes after the initial "connection" to the DockerSwarmComputer (see hudson.model.Computer.getConnectTime() and connectTime variable in DockerSwarmAgentRetentionStrategy.check()).
If the point of time the agent comes online falls together with a retention strategy run and Jenkins just didn't dispatch a build task to the agent yet, the condition in DockerSwarmAgentRetentionStrategy.check() (-> c.isOnline() && isTimeout && (!isTaskAccepted || isTaskCompleted) is met and the agent is inadvertently deleted by the retention strategy.
If this happens, the agent container is removed from the Docker swarm and the assigned build task stays in the build queue forever.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
