### PR TITLE
Add support for Windows dial-in commands

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
@@ -35,7 +35,8 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
     private String portBinds;
     private String label;
     private boolean osWindows;
-    private String command;
+    private String unixCommand;
+    private String windowsCommand;
     private String user;
     private String workingDir;
     private String hosts;
@@ -56,7 +57,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
 
     @DataBoundConstructor
     public DockerSwarmAgentTemplate(final String image, final String hostBinds, final String hostNamedPipes, final String dnsIps,
-            final String dnsSearchDomains, final String command, final String user, final String workingDir,
+            final String dnsSearchDomains, final String unixCommand,final String windowsCommand, final String user, final String workingDir,
             final String hosts, final String secrets, final String configs, final String label, final String cacheDir,
             final String tmpfsDir, final String envVars, final long limitsNanoCPUs, final long limitsMemoryBytes,
             final long reservationsNanoCPUs, final long reservationsMemoryBytes, String portBinds, final boolean osWindows,
@@ -67,7 +68,8 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
         this.hostNamedPipes = hostNamedPipes;
         this.dnsIps = dnsIps;
         this.dnsSearchDomains = dnsSearchDomains;
-        this.command = command;
+        this.unixCommand = unixCommand;
+        this.windowsCommand = windowsCommand;
         this.user = user;
         this.workingDir = workingDir;
         this.hosts = hosts;
@@ -140,8 +142,15 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
         return StringUtils.isEmpty(this.envVars) ? new String[] {} : this.envVars.split("[\\r\\n]+");
     }
 
-    public String[] getCommandConfig() {
-        return StringUtils.isEmpty(this.command) ? new String[] {} : this.command.split("[\\r\\n]+");
+    public String[] getUnixCommandConfig() {
+        return StringUtils.isEmpty(this.unixCommand) ? new String[] {} : this.unixCommand.split("[\\r\\n]+");
+    }
+    public String[] getWindowsCommandConfig() {
+        return StringUtils.isEmpty(this.windowsCommand) ? new String[] {} : this.windowsCommand.split("[\\r\\n\\s]+");
+    }
+
+    public String[] getWindowsCommandConfig(String windowsCommand) {
+        return StringUtils.isEmpty(windowsCommand) ? new String[] {} : windowsCommand.split("[\\r\\n\\s]+");
     }
 
     public String[] getHostsConfig() {
@@ -245,8 +254,12 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
         return configs;
     }
 
-    public String getCommand() {
-        return command;
+    public String getUnixCommand() {
+        return unixCommand;
+    }
+
+    public String getWindowsCommand() {
+        return windowsCommand;
     }
 
     public String getHosts() {

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
@@ -9,8 +9,11 @@
     <f:entry title="Image" field="image">
         <f:textbox value="${dockerSwarmAgentTemplate.image}" default="java:8"/>
     </f:entry>
-    <f:entry title="Command" field="command">
-        <f:textarea value="${dockerSwarmAgentTemplate.command}" default="sh&#10;-cx&#10;curl --connect-timeout 20 --max-time 60 -o agent.jar $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL &amp;&amp; java -jar agent.jar -jnlpUrl $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JNLP_URL -secret $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET -noReconnect -workDir /tmp"/>
+    <f:entry title="Unix Command" field="unixCommand">
+        <f:textarea value="${dockerSwarmAgentTemplate.unixCommand}" default="sh&#10;-cx&#10;curl --connect-timeout 20 --max-time 60 -o agent.jar $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL &amp;&amp; java -jar agent.jar -jnlpUrl $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JNLP_URL -secret $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET -noReconnect -workDir /tmp"/>
+    </f:entry>
+    <f:entry title="Windows Command" field="windowsCommand">
+        <f:textbox value="${dockerSwarmAgentTemplate.windowsCommand}" default="powershell.exe &amp; { Invoke-WebRequest -TimeoutSec 20 -OutFile agent.jar %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL%; if($?) { java -jar agent.jar -jnlpUrl %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JNLP_URL% -secret %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET% -noReconnect } }"/>
     </f:entry>
     <f:entry title="Working Directory" field="workingDir">
         <f:textbox value="${dockerSwarmAgentTemplate.workingDir}" default="/tmp"/>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR enables the user to add a custom Windows command to use for container dial-in, as opposed to the current hard-coded behaviour. On the agent template page, there is now a text area called `Windows Command` (the former `Command` text area has been renamed to `Unix Command`. The motivation behind this is my team's need to allow the containers to connect via cygwin as opposed to powershell. I also made it so one can write `${unixCommand}` on the `Windows Command` field to interpolate the default bash behaviour without needing complicated parsing. 

Closes issue #53.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
