### PR TITLE
Support compilation with Java 11

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/BuildScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/BuildScheduler.java
@@ -18,7 +18,7 @@ public class BuildScheduler {
     private static AtomicInteger counter = new AtomicInteger(1);
 
     public static void scheduleBuild(final Queue.BuildableItem bi) {
-        try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
+        try (ACLContext context = ACL.as(ACL.SYSTEM)) {
             final DockerSwarmLabelAssignmentAction action = createLabelAssignmentAction(bi.task.getDisplayName());
             DockerSwarmAgentInfo dockerSwarmAgentInfo = new DockerSwarmAgentInfo(true);
             dockerSwarmAgentInfo.setAgentLabel(action.getLabel().toString());

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentLauncherActor.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentLauncherActor.java
@@ -66,7 +66,7 @@ public class DockerSwarmAgentLauncherActor extends AbstractActor {
                 logger.println(line);
                 logger.flush();
             }
-        } catch (IOException _) {
+        } catch (IOException unused) {
         } finally {
             response.body().close();
         }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/ResetStuckBuildsInQueueActor.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/ResetStuckBuildsInQueueActor.java
@@ -32,7 +32,7 @@ public class ResetStuckBuildsInQueueActor extends AbstractActor {
     }
 
     private void resetStuckBuildsInQueue() throws IOException {
-        try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
+        try (ACLContext context = ACL.as(ACL.SYSTEM)) {
             long resetMinutes = Optional.ofNullable(DockerSwarmCloud.get().getTimeoutMinutes()).orElse(DEFAULT_RESET_MINUTES);
             final Queue.Item[] items = Jenkins.getInstance().getQueue().getItems();
             for (int i = items.length - 1; i >= 0; i--) { // reverse order


### PR DESCRIPTION
```
src/main/java/org/jenkinsci/plugins/docker/swarm/BuildScheduler.java:21: error: as of release 9, '_' is a keyword, and may not be used as an identifier
src/main/java/org/jenkinsci/plugins/docker/swarm/ResetStuckBuildsInQueueActor.java:35: error: as of release 9, '_' is a keyword, and may not be used as an identifier
src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentLauncherActor.java:69: error: as of release 9, '_' is a keyword, and may not be used as an identifier
```