### PR TITLE
Use `java hudson.remoting.jnlp.Main` not `java -jar agent.jar`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
@@ -81,6 +81,7 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
         final String[] envVarOptions = dockerSwarmAgentTemplate.getEnvVarsConfig();
         final ArrayList<String> envVarsList = new ArrayList<>(Arrays.asList(envVarOptions));
         envVarsList.add("DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET=" + getAgentSecret(computer));
+        envVarsList.add("DOCKER_SWARM_PLUGIN_JENKINS_URL=" + getJenkinsUrl(configuration));
         envVarsList.add("DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL=" + getAgentJarUrl(configuration));
         envVarsList.add("DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JNLP_URL=" + getAgentJnlpUrl(computer, configuration));
         envVarsList.add("DOCKER_SWARM_PLUGIN_JENKINS_AGENT_NAME=" + getAgentName(computer));
@@ -89,7 +90,9 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
         if (dockerSwarmAgentTemplate.isOsWindows()) {
             String command = dockerSwarmAgentTemplate.getWindowsCommand();
             HashMap<String,String> envHashMap = new HashMap<String,String>(){{
+                // TODO derive automatically from above list
                 put("\\%DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET\\%",getAgentSecret(computer));
+                put("\\%DOCKER_SWARM_PLUGIN_JENKINS_URL\\%",getJenkinsUrl(configuration));
                 put("\\%DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL\\%",getAgentJarUrl(configuration));
                 put("\\%DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JNLP_URL\\%",getAgentJnlpUrl(computer, configuration));
                 put("\\%DOCKER_SWARM_PLUGIN_JENKINS_AGENT_NAME\\%",getAgentName(computer));

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
@@ -10,10 +10,10 @@
         <f:textbox value="${dockerSwarmAgentTemplate.image}" default="java:8"/>
     </f:entry>
     <f:entry title="Unix Command" field="unixCommand">
-        <f:textarea value="${dockerSwarmAgentTemplate.unixCommand}" default="sh&#10;-cx&#10;curl --connect-timeout 20 --max-time 60 -o agent.jar $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL &amp;&amp; java -jar agent.jar -jnlpUrl $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JNLP_URL -secret $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET -noReconnect -workDir /tmp"/>
+        <f:textarea value="${dockerSwarmAgentTemplate.unixCommand}" default="sh&#10;-cx&#10;curl --connect-timeout 20 --max-time 60 -o agent.jar $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL &amp;&amp;  java -classpath agent.jar hudson.remoting.jnlp.Main -headless -url $DOCKER_SWARM_PLUGIN_JENKINS_URL -noreconnect -workDir /tmp $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_NAME"/>
     </f:entry>
     <f:entry title="Windows Command" field="windowsCommand">
-        <f:textbox value="${dockerSwarmAgentTemplate.windowsCommand}" default="powershell.exe &amp; { Invoke-WebRequest -TimeoutSec 20 -OutFile agent.jar %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL%; if($?) { java -jar agent.jar -jnlpUrl %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JNLP_URL% -secret %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET% -noReconnect } }"/>
+        <f:textbox value="${dockerSwarmAgentTemplate.windowsCommand}" default="powershell.exe &amp; { Invoke-WebRequest -TimeoutSec 20 -OutFile agent.jar %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL%; if($?) { java -classpath agent.jar hudson.remoting.jnlp.Main -headless -url %DOCKER_SWARM_PLUGIN_JENKINS_URL% -noreconnect %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET% %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_NAME% } }"/>
     </f:entry>
     <f:entry title="Working Directory" field="workingDir">
         <f:textbox value="${dockerSwarmAgentTemplate.workingDir}" default="/tmp"/>

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
@@ -10,7 +10,7 @@
         <f:textbox value="${dockerSwarmAgentTemplate.image}" default="java:8"/>
     </f:entry>
     <f:entry title="Unix Command" field="unixCommand">
-        <f:textarea value="${dockerSwarmAgentTemplate.unixCommand}" default="sh&#10;-cx&#10;curl --connect-timeout 20 --max-time 60 -o agent.jar $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL &amp;&amp;  java -classpath agent.jar hudson.remoting.jnlp.Main -headless -url $DOCKER_SWARM_PLUGIN_JENKINS_URL -noreconnect -workDir /tmp $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_NAME"/>
+        <f:textarea value="${dockerSwarmAgentTemplate.unixCommand}" default="sh&#10;-cx&#10;curl --connect-timeout 20 --max-time 60 -o agent.jar $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL &amp;&amp; java -classpath agent.jar hudson.remoting.jnlp.Main -headless -url $DOCKER_SWARM_PLUGIN_JENKINS_URL -noreconnect -workDir /tmp $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_NAME"/>
     </f:entry>
     <f:entry title="Windows Command" field="windowsCommand">
         <f:textbox value="${dockerSwarmAgentTemplate.windowsCommand}" default="powershell.exe &amp; { Invoke-WebRequest -TimeoutSec 20 -OutFile agent.jar %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL%; if($?) { java -classpath agent.jar hudson.remoting.jnlp.Main -headless -url %DOCKER_SWARM_PLUGIN_JENKINS_URL% -noreconnect %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET% %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_NAME% } }"/>


### PR DESCRIPTION
Allows agents to connect to a Jenkins controller using a non-public URL after https://github.com/jenkinsci/jenkins/pull/4839. https://github.com/KostyaSha/yet-another-docker-plugin/issues/288#issuecomment-687212127 gives some background.