### PR TITLE
Fixing Pipeline resumption

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgent.java
@@ -2,8 +2,6 @@ package org.jenkinsci.plugins.docker.swarm;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -11,17 +9,12 @@ import org.jenkinsci.plugins.docker.swarm.docker.api.service.DeleteServiceReques
 
 import akka.actor.ActorRef;
 import hudson.model.Descriptor;
-import hudson.model.Label;
-import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.TaskListener;
-import hudson.model.labels.LabelAtom;
-import hudson.model.queue.CauseOfBlockage;
 import hudson.slaves.AbstractCloudSlave;
-import hudson.slaves.EphemeralNode;
 import jenkins.model.Jenkins;
 
-public class DockerSwarmAgent extends AbstractCloudSlave implements EphemeralNode {
+public class DockerSwarmAgent extends AbstractCloudSlave {
 
     private static final Logger LOGGER = Logger.getLogger(DockerSwarmAgent.class.getName());
 
@@ -40,40 +33,9 @@ public class DockerSwarmAgent extends AbstractCloudSlave implements EphemeralNod
 
     @Override
     protected void _terminate(final TaskListener listener) throws IOException, InterruptedException {
+        DockerSwarmPlugin swarmPlugin = Jenkins.getInstance().getPlugin(DockerSwarmPlugin.class);
+        ActorRef agentLauncherRef = swarmPlugin.getActorSystem().actorFor("/user/" + getComputer().getName());
+        agentLauncherRef.tell(new DeleteServiceRequest(getComputer().getName()), ActorRef.noSender());
     }
 
-    @Override
-    public Node asNode() {
-        return this;
-    }
-
-    @Override
-    public CauseOfBlockage canTake(final Queue.BuildableItem item) {
-        final Label l = item.getAssignedLabel();
-        if (l != null && this.name.equals(l.getName())) {
-            return null;
-        }
-        return super.canTake(item);
-    }
-
-    @Override
-    public Set<LabelAtom> getAssignedLabels() {
-        final TreeSet<LabelAtom> labels = new TreeSet<>();
-        labels.add(new LabelAtom(getLabelString()));
-        return labels;
-    }
-
-    public void terminate() throws IOException {
-        try {
-            DockerSwarmPlugin swarmPlugin = Jenkins.getInstance().getPlugin(DockerSwarmPlugin.class);
-            ActorRef agentLauncherRef = swarmPlugin.getActorSystem().actorFor("/user/" + getComputer().getName());
-            agentLauncherRef.tell(new DeleteServiceRequest(getComputer().getName()), ActorRef.noSender());
-        } finally {
-            try {
-                Jenkins.getInstance().removeNode(this);
-            } catch (IOException e) {
-                LOGGER.log(Level.WARNING, "Failed to remove computer", e);
-            }
-        }
-    }
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentRetentionStrategy.java
@@ -108,7 +108,7 @@ public class DockerSwarmAgentRetentionStrategy extends RetentionStrategy<DockerS
                 if (node != null) {
                     try {
                         node.terminate();
-                    } catch (IOException e) {
+                    } catch (IOException | InterruptedException e) {
                         LOGGER.log(Level.WARNING, "Failed to terminate " + c.getName(), e);
                     }
                 }

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/OneShotProvisionQueueListener.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/OneShotProvisionQueueListener.java
@@ -40,7 +40,7 @@ public class OneShotProvisionQueueListener extends QueueListener {
                 Computer.threadPoolForRemoting.submit(() -> {
                     try {
                         ((DockerSwarmAgent) node).terminate();
-                    } catch (IOException e) {
+                    } catch (IOException | InterruptedException e) {
                         LOGGER.log(Level.WARNING, "Failed to terminate agent.", e);
                     }
                 });

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/ResetStuckBuildsInQueueActor.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/ResetStuckBuildsInQueueActor.java
@@ -31,7 +31,7 @@ public class ResetStuckBuildsInQueueActor extends AbstractActor {
         return Props.create(ResetStuckBuildsInQueueActor.class, ResetStuckBuildsInQueueActor::new);
     }
 
-    private void resetStuckBuildsInQueue() throws IOException {
+    private void resetStuckBuildsInQueue() throws IOException, InterruptedException {
         try (ACLContext context = ACL.as(ACL.SYSTEM)) {
             long resetMinutes = Optional.ofNullable(DockerSwarmCloud.get().getTimeoutMinutes()).orElse(DEFAULT_RESET_MINUTES);
             final Queue.Item[] items = Jenkins.getInstance().getQueue().getItems();

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
@@ -10,10 +10,10 @@
         <f:textbox value="${dockerSwarmAgentTemplate.image}" default="java:8"/>
     </f:entry>
     <f:entry title="Unix Command" field="unixCommand">
-        <f:textarea value="${dockerSwarmAgentTemplate.unixCommand}" default="sh&#10;-cx&#10;curl --connect-timeout 20 --max-time 60 -o agent.jar $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL &amp;&amp; java -jar agent.jar -jnlpUrl $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JNLP_URL -secret $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET -noReconnect -workDir /tmp"/>
+        <f:textarea value="${dockerSwarmAgentTemplate.unixCommand}" default="sh&#10;-cx&#10;curl --connect-timeout 20 --max-time 60 -o agent.jar $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL &amp;&amp; java -jar agent.jar -jnlpUrl $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JNLP_URL -secret $DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET -workDir /tmp"/>
     </f:entry>
     <f:entry title="Windows Command" field="windowsCommand">
-        <f:textbox value="${dockerSwarmAgentTemplate.windowsCommand}" default="powershell.exe &amp; { Invoke-WebRequest -TimeoutSec 20 -OutFile agent.jar %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL%; if($?) { java -jar agent.jar -jnlpUrl %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JNLP_URL% -secret %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET% -noReconnect } }"/>
+        <f:textbox value="${dockerSwarmAgentTemplate.windowsCommand}" default="powershell.exe &amp; { Invoke-WebRequest -TimeoutSec 20 -OutFile agent.jar %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JAR_URL%; if($?) { java -jar agent.jar -jnlpUrl %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_JNLP_URL% -secret %DOCKER_SWARM_PLUGIN_JENKINS_AGENT_SECRET% } }"/>
     </f:entry>
     <f:entry title="Working Directory" field="workingDir">
         <f:textbox value="${dockerSwarmAgentTemplate.workingDir}" default="/tmp"/>


### PR DESCRIPTION
381d0d06300e7b40aa8dc324292e2ea80c67e728 implied that this plugin allowed builds to survive controller restarts, but they did not. To start with, no one should be using `EphemeralNode` any more, as it completely prevents the agent from reattaching to the controller after a restart and thus letting Pipeline builds resume; as did the recommended use of `-noreconnect`. Then 5d2a8f16e8e35656e0f4236505614ff65dfcae7f, some sort of optimization which is probably now obsolete (see for example https://github.com/jenkinsci/jenkins/pull/8395), prevented the `PlaceholderTask` from restarting on the agent even after it reconnected. The purpose of `canTake` in 6721e1c27678c6d02c5cb6b3df9007bea764c1b7 is also unclear and apparently unnecessary. Also simplified by using `_terminate` rather than overriding `terminate`.