### PR TITLE
Improve help function and add option to specify a volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ Next you need to add one or more agent templates. Make sure to set a `label`. A 
 The plugin attempts to create an agent as soon as build enters the queue. Bypassing cloud apis for faster agent scheduling.
 
 ## Caching
-Caching is done via [docker volume plugin](https://github.com/suryagaddipati/docker-cache-volume-plugin).
+There are 2 options:
+1. **Caching is done via [docker volume plugin](https://github.com/suryagaddipati/docker-cache-volume-plugin).**
 Driver gets called to create an overlayfs cache volume for each build and once build is done volume gets deleted. This cache volume is mounted into agent in the directory specified by `Cache Dir` configuration option in Agent Templates.  On delete if there are any new changes to cache they get copied into a new basedir and pointer to baseCache gets updated. You can optionally mount lower base cache dir onto a NFS storage appliance. Checkout plugin documentation for more details.
+1. **Caching is done via the default docker volume driver.** To activate it, type `local` into the `Cache driver name` field in the docker swarm cloud configuration.
+Watch out for concurrent access as it is possible for 2 containers to access the same cache at the same time. This is not an issue if you use it as a repository cache when controlled by git or mercurial. They have internal mechanisms for serializing access.
 
 ## Swarm Dashboard
 Follow the link `Docker Swarm Dashboard` on the sidebar to view the status of your swarm. It displays what build is executing where, what builds are in the queue for what resources ect.

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate.java
@@ -43,6 +43,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
     private String hosts;
 
     private String cacheDir;
+    private String volumeDir;
     private String envVars;
     private String baseWorkspaceLocation;
     private String placementConstraints;
@@ -60,7 +61,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
     public DockerSwarmAgentTemplate(final String image, final String hostBinds, final String hostNamedPipes, final String dnsIps,
             final String dnsSearchDomains, final String unixCommand,final String windowsCommand, final String user, final String workingDir,
             final String hosts, final String metadata, final String secrets, final String configs, final String label, final String cacheDir,
-            final String tmpfsDir, final String envVars, final long limitsNanoCPUs, final long limitsMemoryBytes,
+            final String volumeDir, final String tmpfsDir, final String envVars, final long limitsNanoCPUs, final long limitsMemoryBytes,
             final long reservationsNanoCPUs, final long reservationsMemoryBytes, String portBinds, final boolean osWindows,
             final String baseWorkspaceLocation, final String placementConstraints, final String placementArchitecture,
             final String placementOperatingSystem, final String email, final String serverAddress, final String pullCredentialsId) {
@@ -79,6 +80,7 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
         this.configs = configs;
         this.label = label;
         this.cacheDir = cacheDir;
+        this.volumeDir = volumeDir;
         this.tmpfsDir = tmpfsDir;
         this.limitsNanoCPUs = limitsNanoCPUs;
         this.limitsMemoryBytes = limitsMemoryBytes;
@@ -98,6 +100,10 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
 
     public String[] getCacheDirs() {
         return StringUtils.isEmpty(this.cacheDir) ? new String[] {} : this.cacheDir.split("[\\r\\n ]+");
+    }
+
+    public String[] getVolumeDirs() {
+        return StringUtils.isEmpty(this.volumeDir) ? new String[] {} : this.volumeDir.split("[\\r\\n ]+");
     }
 
     public String getLabel() {
@@ -284,6 +290,10 @@ public class DockerSwarmAgentTemplate implements Describable<DockerSwarmAgentTem
 
     public String getCacheDir() {
         return cacheDir;
+    }
+
+    public String getVolumeDir() {
+        return volumeDir;
     }
 
     public String getUser() {

--- a/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/swarm/DockerSwarmComputerLauncher.java
@@ -151,6 +151,7 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
         setConfigs(dockerSwarmAgentTemplate, crReq);
         setNetwork(configuration, crReq);
         setCacheDirs(configuration, dockerSwarmAgentTemplate, listener, computer, crReq);
+        setVolumeDirs(configuration, dockerSwarmAgentTemplate, listener, computer, crReq);
         setTmpfs(dockerSwarmAgentTemplate, crReq);
         setPlacement(dockerSwarmAgentTemplate, crReq);
         setLabels(crReq);
@@ -202,8 +203,21 @@ public class DockerSwarmComputerLauncher extends JNLPLauncher {
             final String cacheVolumeName = getJobName() + "-" + computer.getVolumeName();
             this.bi.getAction(DockerSwarmAgentInfo.class).setCacheVolumeName(cacheVolumeName);
             for (int i = 0; i < cacheDirs.length; i++) {
-                listener.getLogger().println("Binding Volume" + cacheDirs[i] + " to " + cacheVolumeName);
+                listener.getLogger().println("Binding Volume " + cacheVolumeName + " to " + cacheDirs[i]);
                 crReq.addCacheVolume(cacheVolumeName, cacheDirs[i], configuration.getCacheDriverName());
+            }
+        }
+    }
+
+    private void setVolumeDirs(DockerSwarmCloud configuration, DockerSwarmAgentTemplate dockerSwarmAgentTemplate,
+            TaskListener listener, DockerSwarmComputer computer, ServiceSpec crReq) {
+        final String[] volumeDirs = dockerSwarmAgentTemplate.getVolumeDirs();
+        if (volumeDirs.length > 0) {
+            for (int i = 0; i < volumeDirs.length; i++) {
+                final String cacheVolumeName = volumeDirs[i].split(":")[0];
+                final String mountDir = volumeDirs[i].split(":")[1];
+                listener.getLogger().println("Binding Volume " + cacheVolumeName + " to " + mountDir);
+                crReq.addCacheVolume(cacheVolumeName, mountDir, configuration.getCacheDriverName());
             }
         }
     }

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/config.jelly
@@ -54,6 +54,9 @@
     <f:entry title="Cache Dirs (newline-separated)" field="cacheDir">
         <f:expandableTextbox value="${dockerSwarmAgentTemplate.cacheDir}"/>
     </f:entry>
+    <f:entry title="Docker volumes (newline-separated)" field="volumeDir">
+        <f:expandableTextbox value="${dockerSwarmAgentTemplate.volumeDir}"/>
+    </f:entry>
 
     <f:entry title="Tmpfs Dir" field="tmpfsDir">
         <f:textbox value="${dockerSwarmAgentTemplate.tmpfsDir}"/>

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/help-cacheDir.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/help-cacheDir.html
@@ -1,0 +1,6 @@
+<div>
+    <p>Option to enable a volume and mount to the specified folder. The Volume name will be uniquely generated per node and per job. This makes it possible to have a cache for a job which is node persistent. For the behavior in case of concurrent access, see documanetation of the docker storage driver you are using.</p>
+    <code>
+        /FolderToMountVolume
+    </code>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/help-volumeDir.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmAgentTemplate/help-volumeDir.html
@@ -1,0 +1,9 @@
+<div>
+    <p>
+        Option to enable a custom volume and mount to the specified folder. Similar to 'Cache dirs', except that you can choose here the volume name. Hence it will not be unique per job.
+        This is interesting if you want to reuse information between multiple jobs or just to save disk space. One of the use cases can be as a repository cache.
+    </p>
+    <code>
+        volumeName:/FolderToMountVolume
+    </code>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/swarm/DockerSwarmCloud/config.jelly
@@ -12,7 +12,7 @@
             <f:textbox/>
         </f:entry>
         <f:entry title="Cache driver name" field="cacheDriverName">
-            <f:textbox/>
+            <f:textbox default="local"/>
         </f:entry>
         <f:entry title="Tunnel" field="tunnel">
             <f:textbox/>


### PR DESCRIPTION
Improved help function for cache dir and docker volume driver + adding a field to create a plain docker volume
See commit messages for more info. 

### Testing done
These 3 commits are already active through a self built docker swarm plugin on our own Jenkins and running for several months.

